### PR TITLE
`include_flamegraph` -> `upload_flamegraph`

### DIFF
--- a/.github/workflows/python-memory-profile.yml
+++ b/.github/workflows/python-memory-profile.yml
@@ -11,7 +11,7 @@ on:
         required: false
         default: ""
         type: string
-      include_flamegraph:
+      upload_flamegraph:
         description: "If True, upload the memory profiling flamegraph as an action artefact"
         required: false
         default: false
@@ -50,11 +50,11 @@ jobs:
           pytest tests/ -p memray -m "high_mem" --no-cov --memray-bin-path=$HOME/flamegraphs --memray-bin-prefix=${{ github.sha }}
 
       - name: Produce flamegraph
-        if: inputs.include_flamegraph == true
+        if: inputs.upload_flamegraph == true
         run: for binfile in $HOME/flamegraphs/*.bin; do memray flamegraph $binfile; done
 
       - name: Upload flamegraph(s)
-        if: inputs.include_flamegraph == true
+        if: inputs.upload_flamegraph == true
         uses: actions/upload-artifact@v3
         with:
           name: memory-profiling-flamegraphs

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ _description_: Run a subset of your tests marked as "high_mem" using [pytest](ht
 _Inputs_:
  - py3version: Minor version of Python version 3 to run the test on (e.g. `11` for python v3.11).
  - additional_mamba_args (optional, default=""): Any additional arguments to pass to micromamba when creating the python environment.
- - include_flamegraph (optional, default=False): If True, upload the memory profiling flamegraph as an action artefact.
+ - upload_flamegraph (optional, default=False): If True, upload the memory profiling flamegraph as an action artefact.
 
 _Required secrets_: None
 


### PR DESCRIPTION
More intuitive argument naming.