### PR TITLE
Update mamba env names to include repository prefix

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -25,7 +25,7 @@ jobs:
     - uses: mamba-org/setup-micromamba@v1
       with:
         micromamba-version: latest
-        environment-name: docs
+        environment-name: ${{ github.event.repository.name }}-docs
         environment-file: requirements/base.txt
         create-args: >-
             -c city-modelling-lab

--- a/.github/workflows/python-install-lint-test.yml
+++ b/.github/workflows/python-install-lint-test.yml
@@ -70,7 +70,7 @@ jobs:
     - uses: mamba-org/setup-micromamba@v1
       with:
         micromamba-version: latest
-        environment-name: ${{ env.MAMBAENVNAME }}
+        environment-name: ${{ github.event.repository.name }}-${{ env.MAMBAENVNAME }}
         environment-file: requirements/base.txt
         create-args: >-
           ${{ inputs.additional_mamba_args }}

--- a/.github/workflows/python-memory-profile.yml
+++ b/.github/workflows/python-memory-profile.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: mamba-org/setup-micromamba@v1
         with:
           micromamba-version: latest
-          environment-name: ubuntu-latest-3${{ inputs.py3version }}-profiling
+          environment-name: ${{ github.event.repository.name }}-ubuntu-latest-3${{ inputs.py3version }}-profiling
           environment-file: requirements/base.txt
           create-args: >-
             ${{ inputs.additional_mamba_args }}


### PR DESCRIPTION
Feels safer to have the env cache clearly linked to the caller repo.