### PR TITLE
Add template checker

### DIFF
--- a/.github/workflows/template-check.yml
+++ b/.github/workflows/template-check.yml
@@ -19,6 +19,11 @@ jobs:
           post-cleanup: all
           cache-environment: true
 
+      - name: Update GitHub credentials
+        run: |
+          git config --global user.name "${GITHUB_ACTOR}"
+          git config --global user.email "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com"
+
       - name: Check project against template
         id: check
         run: cruft check

--- a/.github/workflows/template-check.yml
+++ b/.github/workflows/template-check.yml
@@ -2,6 +2,10 @@ name: Reusable template checker
 on:
   workflow_call:
 
+defaults:
+  run:
+    shell: bash -l {0}
+
 jobs:
   cruft-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/template-check.yml
+++ b/.github/workflows/template-check.yml
@@ -19,10 +19,10 @@ jobs:
           post-cleanup: all
           cache-environment: true
 
-      - name: Update GitHub credentials
+      - name: Add dummy GitHub credentials
         run: |
-          git config --global user.email "you@example.com"
-          git config --global user.name "GitHub"
+          git config --global user.name Cruft check
+          git config --global user.email check@dummy.bot.com
 
       - name: Check project against template
         id: check

--- a/.github/workflows/template-check.yml
+++ b/.github/workflows/template-check.yml
@@ -21,8 +21,8 @@ jobs:
 
       - name: Update GitHub credentials
         run: |
-          git config --global user.name "${GITHUB_ACTOR}"
-          git config --global user.email "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com"
+          git config --global user.email "you@example.com"
+          git config --global user.name "GitHub"
 
       - name: Check project against template
         id: check

--- a/.github/workflows/template-check.yml
+++ b/.github/workflows/template-check.yml
@@ -1,0 +1,20 @@
+name: Reusable template checker
+on:
+  workflow_call:
+
+jobs:
+  cruft-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: mamba-org/setup-micromamba@v1
+        with:
+          micromamba-version: latest
+          environment-name: ${{ github.event.repository.name }}-cruft
+          create-args: cruft python=3.11
+          post-cleanup: all
+          cache-environment: true
+
+      - name: Check project against template
+        id: check
+        run: cruft check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Run tests on python package
     - Run memory profiling tests on python package
     - Notify about action success / failure on a slack channel
+    - Check whether project and parent template have diverged
 
 - GitHub Action to validate the reusable workflows themselves
 

--- a/README.md
+++ b/README.md
@@ -204,3 +204,9 @@ _Inputs_:
  - message: Sub-string to include in the message, e.g. the name of the "caller" workflow.
 
 _Required secrets_: `SLACK_WEBHOOK`
+
+### Check if project is up-to-date with parent template
+
+_URL_: `arup-group/actions-city-modelling-lab/.github/workflows/template-check.yml`
+
+_description_: If your project was generated using a [cookiecutter](https://github.com/cookiecutter/cookiecutter) template, check whether there are changes to the template that could be pulled into the project.


### PR DESCRIPTION
The idea is that any projects built from templates (e.g. [our python package one](https://github.com/arup-group/cookiecutter-pypackage/)) can look to the template for any updates. It won't attempt to implement updates, but will fail when the upstream project has updates that could be worth incorporating into the current repo (e.g., slight changes to config).