### PR TITLE
Update conda build

### DIFF
--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -17,6 +17,9 @@ on:
         required: false
         type: string
         default: ${{ github.ref_name }}
+    secrets:
+      ANACONDA_TOKEN:
+        required: true
 
 defaults:
   run:

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -82,7 +82,7 @@ jobs:
         conda mambabuild --output-folder ${{ runner.temp }}/conda_builds ${{ inputs.recipe_dir }}
 
     - name: Test installing built conda package
-      run: conda install -c ${{ runner.temp }}/conda_builds ${{ inputs.package_name }}
+      run: conda install -c file://${{ runner.temp }}/conda_builds ${{ inputs.package_name }}
 
     - name: Upload built conda package ready for upload on release
       uses: actions/upload-artifact@v3

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -37,9 +37,9 @@ jobs:
         run: |
           if grep -Fq "noarch:" ${{ inputs.recipe_dir }}/meta.yaml
           then
-            echo "matrix={\"os\":[\"ubuntu-latest\"]}" >> $GITHUB_OUTPUT
+            echo "matrix={\"os\":[\"ubuntu-latest\"], \"pyversion\":[\"11\"]}" >> $GITHUB_OUTPUT
           else
-            echo "matrix={\"os\":[\"ubuntu-latest\", \"macos-latest\", \"windows-latest\"]}" >> $GITHUB_OUTPUT
+            echo "matrix={\"os\":[\"ubuntu-latest\", \"macos-latest\", \"windows-latest\"], \"pyversion\":[\"9\", \"10\", \"11\"]}" >> $GITHUB_OUTPUT
           fi
 
   token-exists:
@@ -68,7 +68,7 @@ jobs:
         micromamba-version: latest
         environment-name: condabuild
         create-args: >-
-          python=3.11
+          python=3.${{ matrix.pyversion }}
           boa
           conda-verify
         post-cleanup: all
@@ -86,7 +86,7 @@ jobs:
     - name: Upload built conda package ready for upload on release
       uses: actions/upload-artifact@v3
       with:
-        name: conda-build-${{ matrix.os }}-${{ inputs.package_name }}-${{ inputs.version }}
+        name: conda-build-${{ matrix.os }}-py3${{ matrix.pyversion }}-${{ inputs.package_name }}-${{ inputs.version }}
         path: ${{ env.MAMBA_ROOT_PREFIX }}/envs/condabuild/conda-bld/
         retention-days: 3
         if-no-files-found: error

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -39,7 +39,7 @@ jobs:
           then
             echo "matrix={\"os\":[\"ubuntu-latest\"]}" >> $GITHUB_OUTPUT
           else
-            echo "matrix={\"os\":[\"ubuntu-latest\", \"macos-latest\", \"windows-latest\"]}" >> $GITHUB_OUTPUT
+            echo "matrix={\"os\":[\"ubuntu-latest\", \"macos-latest\", \"windows-2019\"]}" >> $GITHUB_OUTPUT
           fi
 
   token-exists:

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -82,7 +82,7 @@ jobs:
         conda mambabuild --output-folder ${{ runner.temp }}/conda_builds ${{ inputs.recipe_dir }}
 
     - name: Test installing built conda package
-      run: mamba install -c ${{ runner.temp }}/conda_builds ${{ inputs.package_name }}
+      run: conda install -c ${{ runner.temp }}/conda_builds ${{ inputs.package_name }}
 
     - name: Upload built conda package ready for upload on release
       uses: actions/upload-artifact@v3

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -82,7 +82,7 @@ jobs:
         conda mambabuild --output-folder ${{ runner.temp }}/conda_builds ${{ inputs.recipe_dir }}
 
     - name: Test installing built conda package
-      run: mamba install ${{ runner.temp }}/conda_builds/**/*
+      run: mamba install --use-local ${{ inputs.package_name }}
 
     - name: Upload built conda package ready for upload on release
       uses: actions/upload-artifact@v3

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -37,9 +37,9 @@ jobs:
         run: |
           if grep -Fq "noarch:" ${{ inputs.recipe_dir }}/meta.yaml
           then
-            echo "matrix={\"os\":[\"ubuntu-latest\"], \"pyversion\":[\"11\"]}" >> $GITHUB_OUTPUT
+            echo "matrix={\"os\":[\"ubuntu-latest\"]}" >> $GITHUB_OUTPUT
           else
-            echo "matrix={\"os\":[\"ubuntu-latest\", \"macos-latest\", \"windows-latest\"], \"pyversion\":[\"9\", \"10\", \"11\"]}" >> $GITHUB_OUTPUT
+            echo "matrix={\"os\":[\"ubuntu-latest\", \"macos-latest\", \"windows-latest\"]}" >> $GITHUB_OUTPUT
           fi
 
   token-exists:
@@ -68,7 +68,7 @@ jobs:
         micromamba-version: latest
         environment-name: condabuild
         create-args: >-
-          python=3.${{ matrix.pyversion }}
+          python=3.11
           boa
           conda-verify
         post-cleanup: all
@@ -86,7 +86,7 @@ jobs:
     - name: Upload built conda package ready for upload on release
       uses: actions/upload-artifact@v3
       with:
-        name: conda-build-${{ matrix.os }}-py3${{ matrix.pyversion }}-${{ inputs.package_name }}-${{ inputs.version }}
+        name: conda-build-${{ matrix.os }}-${{ inputs.package_name }}-${{ inputs.version }}
         path: ${{ env.MAMBA_ROOT_PREFIX }}/envs/condabuild/conda-bld/
         retention-days: 3
         if-no-files-found: error

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -82,7 +82,7 @@ jobs:
         conda mambabuild --output-folder ${{ runner.temp }}/conda_builds ${{ inputs.recipe_dir }}
 
     - name: Test installing built conda package
-      run: mamba install -c file://${{ runner.temp }}/conda_builds ${{ inputs.package_name }}
+      run: mamba install -c ${{ runner.temp }}/conda_builds ${{ inputs.package_name }}
 
     - name: Upload built conda package ready for upload on release
       uses: actions/upload-artifact@v3

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -80,8 +80,17 @@ jobs:
     - name: Build conda package
       run: conda mambabuild ${{ inputs.recipe_dir }}
 
+    - name: Get version without the v
+      run: |
+        TAG=${{ inputs.version }}
+        echo "VERSION=${TAG#v}" >> $GITHUB_ENV
+
     - name: Test installing built conda package
-      run: mamba install --use-local ${{ inputs.package_name }}
+      run: |
+        mamba install --use-local ${{ inputs.package_name }}
+        INSTALLED=mamba list ${{ inputs.package_name }}
+        echo $INSTALLED
+        echo "$INSTALLED" | grep "${{ env.VERSION }}" -Fq
 
     - name: Upload built conda package ready for upload on release
       uses: actions/upload-artifact@v3

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -82,7 +82,7 @@ jobs:
         conda mambabuild --output-folder ${{ runner.temp }}/conda_builds ${{ inputs.recipe_dir }}
 
     - name: Test installing built conda package
-      run: mamba install --use-local ${{ inputs.package_name }}
+      run: mamba install -c file://${{ runner.temp }}/conda_builds ${{ inputs.package_name }}
 
     - name: Upload built conda package ready for upload on release
       uses: actions/upload-artifact@v3

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -39,7 +39,7 @@ jobs:
           then
             echo "matrix={\"os\":[\"ubuntu-latest\"]}" >> $GITHUB_OUTPUT
           else
-            echo "matrix={\"os\":[\"ubuntu-latest\", \"macos-latest\", \"windows-2019\"]}" >> $GITHUB_OUTPUT
+            echo "matrix={\"os\":[\"ubuntu-latest\", \"macos-latest\", \"windows-latest\"]}" >> $GITHUB_OUTPUT
           fi
 
   token-exists:

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -39,7 +39,7 @@ jobs:
           then
             echo "matrix={\"os\":[\"ubuntu-latest\"]}" >> $GITHUB_OUTPUT
           else
-            echo "matrix::{\"os\":[\"ubuntu-latest\", \"macos-latest\", \"windows-latest\"]}" >> $GITHUB_OUTPUT
+            echo "matrix={\"os\":[\"ubuntu-latest\", \"macos-latest\", \"windows-latest\"]}" >> $GITHUB_OUTPUT
           fi
 
   token-exists:

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -72,6 +72,7 @@ jobs:
           boa
           conda-verify
         post-cleanup: all
+        cache-environment: true
 
     - name: Add conda channel
       run: conda config --add channels city-modelling-lab
@@ -86,5 +87,6 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: conda-build-${{ matrix.os }}-${{ inputs.package_name }}-${{ inputs.version }}
-        path: $MAMBA_ROOT_PREFIX/envs/condabuild/conda-bld/
-        retention-days: 7
+        path: ${{ env.MAMBA_ROOT_PREFIX }}/envs/condabuild/conda-bld/
+        retention-days: 3
+        if-no-files-found: error

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -7,16 +7,39 @@ on:
         description: "Name of Python package name being built"
         required: true
         type: string
-    secrets:
-      ANACONDA_TOKEN:
-        required: true
+      recipe_dir:
+        description: "Directory in which to find the recipe (i.e. config) for building the package"
+        required: false
+        type: string
+        default: "conda.recipe"
+      version:
+        description: "Version to be packaged and uploaded"
+        required: false
+        type: string
+        default: ${{ github.ref_name }}
 
 defaults:
   run:
     shell: bash -l {0}
 
 jobs:
-  conda-build:
+  n-builds:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.get-arch.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: assert whether the build is noarch or not
+        id: get-arch
+        run: |
+          if grep -Fq "noarch:" ${{ inputs.recipe_dir }}/meta.yaml
+          then
+            echo "::set-output name=matrix::{\"os\":[\"ubuntu-latest\", \"macos-latest\", \"windows-latest\"]}"
+          else
+            echo "::set-output name=matrix::{\"os\":[\"ubuntu-latest\"]}"
+          fi
+
+  token-exists:
     runs-on: ubuntu-latest
     steps:
     - name: check if ANACONDA_TOKEN exists
@@ -30,6 +53,12 @@ jobs:
         echo "Please go to \"settings \> secrets \> actions\" to create it before trying to build the conda package."
         exit 1
 
+  conda-build:
+    runs-on: ${{ matrix.os }}
+    needs: [n-builds, token-exists]
+    strategy:
+      matrix: ${{ fromJson(needs.n-builds.outputs.matrix) }}
+    steps:
     - uses: actions/checkout@v3
     - uses: mamba-org/setup-micromamba@v1
       with:
@@ -46,15 +75,15 @@ jobs:
 
     - name: Build conda package
       run: |
-        conda mambabuild .
-        echo "conda_build_dir=$(conda build --output .)" >> "$GITHUB_ENV"
+        mkdir ${{ runner.temp }}/conda_builds
+        conda mambabuild --output-folder ${{ runner.temp }}/conda_builds ${{ inputs.recipe_dir }}
 
     - name: Test installing built conda package
-      run: mamba install --use-local ${{ inputs.package_name }}
+      run: mamba install ${{ runner.temp }}/conda_builds/**/*
 
     - name: Upload built conda package ready for upload on release
       uses: actions/upload-artifact@v3
       with:
-        name: conda-build-${{ github.ref_name }}
-        path: "${{ env.conda_build_dir }}"
+        name: conda-build-${{ matrix.os }}-${{ inputs.package_name }}-${{ inputs.version }}
+        path: ${{ runner.temp }}/conda_builds
         retention-days: 7

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -88,7 +88,7 @@ jobs:
     - name: Test installing built conda package
       run: |
         mamba install --use-local ${{ inputs.package_name }}
-        INSTALLED=mamba list ${{ inputs.package_name }}
+        INSTALLED=$(mamba list ${{ inputs.package_name }})
         echo $INSTALLED
         echo "$INSTALLED" | grep "${{ env.VERSION }}" -Fq
 

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -78,15 +78,15 @@ jobs:
 
     - name: Build conda package
       run: |
-        mkdir ${{ runner.temp }}/conda_builds
-        conda mambabuild --output-folder ${{ runner.temp }}/conda_builds ${{ inputs.recipe_dir }}
+        mkdir $HOME/conda-bld
+        conda mambabuild --output-folder $HOME/conda-bld ${{ inputs.recipe_dir }}
 
     - name: Test installing built conda package
-      run: conda install -c file://${{ runner.temp }}/conda_builds ${{ inputs.package_name }}
+      run: conda install -c file://$HOME/conda-bld ${{ inputs.package_name }}
 
     - name: Upload built conda package ready for upload on release
       uses: actions/upload-artifact@v3
       with:
         name: conda-build-${{ matrix.os }}-${{ inputs.package_name }}-${{ inputs.version }}
-        path: ${{ runner.temp }}/conda_builds
+        path: $HOME/conda-bld
         retention-days: 7

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -37,9 +37,9 @@ jobs:
         run: |
           if grep -Fq "noarch:" ${{ inputs.recipe_dir }}/meta.yaml
           then
-            echo "::set-output name=matrix::{\"os\":[\"ubuntu-latest\", \"macos-latest\", \"windows-latest\"]}"
+            echo "matrix={\"os\":[\"ubuntu-latest\"]}" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=matrix::{\"os\":[\"ubuntu-latest\"]}"
+            echo "matrix::{\"os\":[\"ubuntu-latest\", \"macos-latest\", \"windows-latest\"]}" >> $GITHUB_OUTPUT
           fi
 
   token-exists:

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -77,16 +77,14 @@ jobs:
       run: conda config --add channels city-modelling-lab
 
     - name: Build conda package
-      run: |
-        mkdir $HOME/conda-bld
-        conda mambabuild --output-folder $HOME/conda-bld ${{ inputs.recipe_dir }}
+      run: conda mambabuild ${{ inputs.recipe_dir }}
 
     - name: Test installing built conda package
-      run: conda install -c file://$HOME/conda-bld ${{ inputs.package_name }}
+      run: mamba install --use-local ${{ inputs.package_name }}
 
     - name: Upload built conda package ready for upload on release
       uses: actions/upload-artifact@v3
       with:
         name: conda-build-${{ matrix.os }}-${{ inputs.package_name }}-${{ inputs.version }}
-        path: $HOME/conda-bld
+        path: $MAMBA_ROOT_PREFIX/envs/condabuild/conda-bld/
         retention-days: 7

--- a/.github/workflows/conda-upload.yml
+++ b/.github/workflows/conda-upload.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Download built conda package ready for upload on release
       uses: dawidd6/action-download-artifact@v2
       with:
-        name: conda-build-*-${{ inputs.package_name }}-${{ inputs.version }}
+        name: "conda-build[a-zA-Z0-9-.]*-${{ inputs.package_name }}-${{ inputs.version }}"
         name_is_regexp: true
         workflow: pre-release.yml
         path: ${{ runner.temp }}/conda_builds

--- a/.github/workflows/conda-upload.yml
+++ b/.github/workflows/conda-upload.yml
@@ -31,6 +31,7 @@ jobs:
             python=3.11
             anaconda-client
         post-cleanup: all
+        cache-environment: true
 
     - name: Download built conda package ready for upload on release
       uses: dawidd6/action-download-artifact@v2

--- a/.github/workflows/conda-upload.yml
+++ b/.github/workflows/conda-upload.yml
@@ -48,4 +48,4 @@ jobs:
     - name: Upload to anaconda
       env:
         ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
-      run: anaconda upload ${{ runner.temp }}/conda_builds/${{ inputs.package_name }}-${{ env.VERSION }}-*.tar.bz2
+      run: anaconda upload ${{ runner.temp }}/conda_builds/**/${{ inputs.package_name }}-${{ env.VERSION }}-*.tar.bz2

--- a/.github/workflows/conda-upload.yml
+++ b/.github/workflows/conda-upload.yml
@@ -5,6 +5,11 @@ on:
         description: "Name of Python package name being uploaded"
         required: true
         type: string
+      version:
+        description: "Version to be packaged and uploaded"
+        required: false
+        type: string
+        default: ${{ github.ref_name }}
     secrets:
       ANACONDA_TOKEN:
         required: true
@@ -30,13 +35,14 @@ jobs:
     - name: Download built conda package ready for upload on release
       uses: dawidd6/action-download-artifact@v2
       with:
-        name: conda-build-${{ github.ref_name }}
+        name: conda-build-*-${{ inputs.package_name }}-${{ inputs.version }}
+        name_is_regexp: true
         workflow: pre-release.yml
         path: ${{ runner.temp }}/conda_builds
 
     - name: Get version without the v
       run: |
-        TAG=${{ github.ref_name }}
+        TAG=${{ inputs.version }}
         echo "VERSION=${TAG#v}" >> $GITHUB_ENV
 
     - name: Upload to anaconda

--- a/.github/workflows/conda-upload.yml
+++ b/.github/workflows/conda-upload.yml
@@ -11,9 +11,10 @@ on:
         type: string
         default: ${{ github.ref_name }}
       build_workflow:
-        description: "Name of workflow file used to build the package initially"
-        required: true
+        description: "Name of workflow file used to build the package initially, if different from current workflow"
+        required: false
         type: string
+        default: ""
     secrets:
       ANACONDA_TOKEN:
         required: true
@@ -25,6 +26,8 @@ defaults:
 jobs:
   conda-publish:
     runs-on: ubuntu-latest
+    env:
+      PACKAGENAME: "conda-build[a-zA-Z0-9-.]*-${{ inputs.package_name }}-${{ inputs.version }}"
     steps:
     - uses: actions/checkout@v3
     - uses: mamba-org/setup-micromamba@v1
@@ -35,14 +38,24 @@ jobs:
             python=3.11
             anaconda-client
         post-cleanup: all
-        cache-environment: true
+        cache-environment: True
 
-    - name: Download built conda package ready for upload on release
+    - name: Download built conda package from another workflow
+      if: inputs.build_workflow != ''
       uses: dawidd6/action-download-artifact@v2
       with:
-        name: "conda-build[a-zA-Z0-9-.]*-${{ inputs.package_name }}-${{ inputs.version }}"
+        name: ${{ env.PACKAGENAME }}
         name_is_regexp: true
         workflow: ${{ inputs.build_workflow }}
+        path: ${{ runner.temp }}/conda_builds
+
+    - name: Download built conda package from same workflow
+      if: inputs.build_workflow == ''
+      uses: dawidd6/action-download-artifact@v2
+      with:
+        name: ${{ env.PACKAGENAME }}
+        name_is_regexp: true
+        run_id: ${{ github.run_id }}
         path: ${{ runner.temp }}/conda_builds
 
     - name: Get version without the v

--- a/.github/workflows/conda-upload.yml
+++ b/.github/workflows/conda-upload.yml
@@ -10,6 +10,10 @@ on:
         required: false
         type: string
         default: ${{ github.ref_name }}
+      build_workflow:
+        description: "Name of workflow file used to build the package initially"
+        required: true
+        type: string
     secrets:
       ANACONDA_TOKEN:
         required: true
@@ -38,7 +42,7 @@ jobs:
       with:
         name: "conda-build[a-zA-Z0-9-.]*-${{ inputs.package_name }}-${{ inputs.version }}"
         name_is_regexp: true
-        workflow: pre-release.yml
+        workflow: ${{ inputs.build_workflow }}
         path: ${{ runner.temp }}/conda_builds
 
     - name: Get version without the v

--- a/.github/workflows/conda-upload.yml
+++ b/.github/workflows/conda-upload.yml
@@ -51,11 +51,8 @@ jobs:
 
     - name: Download built conda package from same workflow
       if: inputs.build_workflow == ''
-      uses: dawidd6/action-download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
-        name: ${{ env.PACKAGENAME }}
-        name_is_regexp: true
-        run_id: ${{ github.run_id }}
         path: ${{ runner.temp }}/conda_builds
 
     - name: Get version without the v

--- a/.github/workflows/conda-upload.yml
+++ b/.github/workflows/conda-upload.yml
@@ -63,4 +63,4 @@ jobs:
     - name: Upload to anaconda
       env:
         ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
-      run: anaconda upload ${{ runner.temp }}/conda_builds/**/${{ inputs.package_name }}-${{ env.VERSION }}-*.tar.bz2
+      run: find ${{ runner.temp }}/conda_builds -path "**/${{ inputs.package_name }}-${{ env.VERSION }}-*.tar.bz2" -exec anaconda upload {} +


### PR DESCRIPTION
I have started our own mini `conda-forge`-like feedstock repo because getting packages onto conda-forge can take forever (see my [s2sphere PR](https://github.com/conda-forge/staged-recipes/pull/23041)).

These changes make the conda build/uploading more robust to handle different types of file builds (inc. python bindings to C/C++ tools).