### PR TITLE
Add dev requirements hash to env name

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -38,7 +38,7 @@ jobs:
     - uses: mamba-org/setup-micromamba@v1
       with:
         micromamba-version: latest
-        environment-name: ${{ github.event.repository.name }}-docs
+        environment-name: ${{ github.event.repository.name }}-docs-${{ hashFiles('requirements/dev.txt') }}
         environment-file: requirements/base.txt
         create-args: >-
             -c city-modelling-lab

--- a/.github/workflows/python-install-lint-test.yml
+++ b/.github/workflows/python-install-lint-test.yml
@@ -61,7 +61,7 @@ jobs:
 
     - name: Create Mamba environment name based on OS and python version
       if: inputs.mamba_env_name == ''
-      run: echo "MAMBAENVNAME=${{ inputs.os }}-3${{ inputs.py3version }}" >> $GITHUB_ENV
+      run: echo "MAMBAENVNAME=${{ inputs.os }}-3${{ inputs.py3version }}-${{ hashFiles('requirements/dev.txt') }}" >> $GITHUB_ENV
 
     - uses: mamba-org/setup-micromamba@v1
       with:

--- a/.github/workflows/python-memory-profile.yml
+++ b/.github/workflows/python-memory-profile.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: mamba-org/setup-micromamba@v1
         with:
           micromamba-version: latest
-          environment-name: ${{ github.event.repository.name }}-ubuntu-latest-3${{ inputs.py3version }}-profiling
+          environment-name: ${{ github.event.repository.name }}-ubuntu-latest-3${{ inputs.py3version }}-profiling-${{ hashFiles('requirements/dev.txt') }}
           environment-file: requirements/base.txt
           create-args: >-
             ${{ inputs.additional_mamba_args }}


### PR DESCRIPTION
This ensures that if there are changes in `requirements/dev.txt`, it will trigger an update to the env rather than resotring from cache. 

This is because `requirements/dev.txt` is in the mamba args list. Changes in `requirements/base.txt` will already trigger a cache refresh.