### PR TITLE
Mamba to micromamba in conda build

### DIFF
--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -61,6 +61,7 @@ jobs:
     needs: [n-builds, token-exists]
     strategy:
       matrix: ${{ fromJson(needs.n-builds.outputs.matrix) }}
+      fail-fast: false
     steps:
     - uses: actions/checkout@v3
     - uses: mamba-org/setup-micromamba@v1

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -61,7 +61,6 @@ jobs:
     needs: [n-builds, token-exists]
     strategy:
       matrix: ${{ fromJson(needs.n-builds.outputs.matrix) }}
-      fail-fast: false
     steps:
     - uses: actions/checkout@v3
     - uses: mamba-org/setup-micromamba@v1

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -87,8 +87,8 @@ jobs:
 
     - name: Test installing built conda package
       run: |
-        mamba install --use-local ${{ inputs.package_name }}
-        INSTALLED=$(mamba list ${{ inputs.package_name }})
+        micromamba install -c local ${{ inputs.package_name }}
+        INSTALLED=$(micromamba list ${{ inputs.package_name }})
         echo $INSTALLED
         echo "$INSTALLED" | grep "${{ env.VERSION }}" -Fq
 


### PR DESCRIPTION
Had an issue where `mamba` wasn't a recognised command; not sure why. [Updates to setup-micromamba](https://github.com/mamba-org/setup-micromamba/releases/tag/v1.5.0) suggests that `micromamba` should definitely be available on PATH, so I've switched to that to be safe.