### PR TITLE
Add `pip_args` input option

### DIFF
--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -16,6 +16,12 @@ on:
         description: "GitHub environment in which secrets are stored"
         type: string
         default: "pre-release"
+      pip_args:
+        description: "Any arguments to pass to pip when running test installations"
+        required: false
+        type: string
+        default: "--no-deps"
+
     secrets:
       TEST_PYPI_API_TOKEN:
         required: true
@@ -88,7 +94,7 @@ jobs:
 
     - name: try installing from local build
       run: |
-        pip install dist/${{ inputs.package_name }}-*.tar.gz
+        pip install ${{inputs.pip_args}} dist/${{ inputs.package_name }}-*.tar.gz
 
   pip-test-upload:  # upload to test-pypi and then check install from there succeeds
     needs: [pip-build, pip-test-build]
@@ -127,4 +133,4 @@ jobs:
     - name: try installing from TestPyPI
       run: |
         cd ${{ runner.temp }}
-        pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple ${{ inputs.package_name }}==${{ env.VERSION }}
+        pip install ${{inputs.pip_args}} -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple ${{ inputs.package_name }}==${{ env.VERSION }}

--- a/README.md
+++ b/README.md
@@ -184,6 +184,9 @@ _Inputs_:
 - environment (optional, default="pre-release"): GitHub environment in which secrets are stored.
 Environments help to ensure that only certain operations are available to different user types.
 E.g., releasing packages can be given an extra layer of security whereby a maintainer has to approve an action before it can run.
+- pip_args (optional, default="--no-deps"). Any arguments to pass to pip when running test installations.
+Many of our packages have non-python dependencies, so it is useful to use `--no-deps` in the installation.
+However, if you know that your library has purely python dependencies then the pip build process is made more robust by removing this argument (i.e. `pip_args: ""`)
 
 _Required secrets_: `TEST_PYPI_API_TOKEN` stored in a GitHub actions environment of the same name as `environment`.
 


### PR DESCRIPTION
In the pip build, we attempt to install the built package locally and from the upload to `test-PyPI`. Ideally, it would be possible for this to include all dependencies as it would confirm that they exist and that appropriate versions of them are available. However, pip doesn't like missing non-python libs (e.g. `gdal-config` stuff), as seen in a recent PAM build: https://github.com/arup-group/pam/actions/runs/8554855177/job/23441151932?pr=272

Rather than revert completely to installing with `--no-deps` (it checks that the package installs, but doesn't attempt to install dependencies), I've made it a configurable option, albeit the default. This would allow a user to remove `--no-deps` if their dependencies allow for it, paving the way for a more robust build test.