### PR TITLE
Add an optional image-tag input param to the S3 upload action

### DIFF
--- a/.github/workflows/aws-upload.yml
+++ b/.github/workflows/aws-upload.yml
@@ -8,6 +8,16 @@ on:
         required: true
       AWS_S3_CODE_BUCKET:
         required: true
+    inputs:
+      image-tag:
+        description: >
+         An optional value to write into an image_tags file
+         before zipping and uploading the repo contents. The
+         image_tags file is used in some downstream Docker image
+         builds to tag the image with arbitrary values.
+        required: false
+        type: string
+        default: 'no-tags'
 
 jobs:
   upload-to-aws:
@@ -26,6 +36,11 @@ jobs:
         release_name=`echo ${{ github.actor }}-${{ github.ref_name }}`
         echo "Release name: $release_name"
         echo $release_name > release_name
+    - name: Add optional image tags
+      if: inputs.image-tag != 'no-tags'
+      run: |
+        echo "Making an image_tags file with tag value: ${{ inputs.image-tag }}"
+        echo ${{ inputs.image-tag }} > image_tags
     - name: Zip release
       run: |
         echo ${{ github.sha }} > release


### PR DESCRIPTION
- Closes #19 

## Verifying the change

I have tested this using a branch of Gelato (PR for that soon @KasiaKoz). That caller build uses the AWS upload action from this branch, configured thus:

```yaml
jobs:
  verify:
    name: Verify
    runs-on: ubuntu-latest
    outputs:
      image-tag: ${{ steps.make-image-tags.outputs.IMAGE_TAG }}

    - name: Make image tags
      id: make-image-tags
      run: |
        artifact=`grep "<artifactId" pom.xml | head -n 1 | awk -F"<artifactId>" '{print $2}' | awk -F "</artifactId" '{print $1}'`
        version=`grep "<version" pom.xml | head -n 1 | awk -F"<version>" '{print $2}' | awk -F "</version" '{print $1}'`
        version_tag=$artifact-$version-$branch-$GITHUB_SHA
        echo "Image version tag: $version_tag"
        echo "IMAGE_TAG=$version_tag" >> "$GITHUB_OUTPUT"

  aws-upload:
    needs: verify
    if: needs.verify.result == 'success'
    uses: arup-group/actions-city-modelling-lab/.github/workflows/aws-upload.yml@add-input-param-to-s3-upload-action
    secrets: inherit
    with:
      image-tag: ${{ needs.verify.outputs.image-tag }}
```

### Build result

The build ran to completion:

<img width="1235" alt="Screenshot 2024-05-24 at 17 10 19" src="https://github.com/arup-group/actions-city-modelling-lab/assets/250899/323c766f-6350-485a-b3e5-7683cc27c389">

### Verifying the uploaded zip file

I grabbed the uploaded zip file from S3 and confirmed that it contains the expected `image_tags` file:

```shell
unzip -p gelato-repo-new-3.zip image_tags > extracted_image_tags; cat extracted_image_tags
gelato-0.0.4-alpha--c73430e02514cf29dd46c076956bfae8cbf3946c
```
 