### PR TITLE
Add docs accessibility (a11y) checker

### DIFF
--- a/.github/workflows/docs-a11y.yml
+++ b/.github/workflows/docs-a11y.yml
@@ -1,0 +1,107 @@
+on:
+  workflow_call:
+    inputs:
+      upload_report:
+        description: "If true, upload a workflow artifact containing a HTML accessibility report."
+        required: false
+        type: boolean
+        default: true
+      allow_pr_comment:
+        description: "If true, allow a bot to comment a text accessibility report in the PR."
+        required: false
+        type: boolean
+        default: true
+      notebook_kernel:
+        description: "If jupyter notebooks are included in the docs, specify the kernel name they expect, e.g. the package name"
+        required: false
+        type: string
+
+defaults:
+  run:
+    shell: bash -l {0}
+
+jobs:
+  docs-accessibility:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v3
+    - uses: mamba-org/setup-micromamba@v1
+      with:
+        micromamba-version: latest
+        environment-name: ${{ github.event.repository.name }}-docs-${{ hashFiles('requirements/dev.txt') }}
+        environment-file: requirements/base.txt
+        create-args: >-
+            -c city-modelling-lab
+            -f requirements/dev.txt
+            python=3.11
+        post-cleanup: all
+        cache-environment: true
+
+    - name: Install package
+      run: pip install --no-dependencies -e .
+
+    - name: install jupyter kernel
+      if: inputs.notebook_kernel != ''
+      run: python -m ipykernel install --user --name ${{ inputs.notebook_kernel }}
+
+    - name: build docs
+      run: mkdocs build
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 16
+
+    - name: Install Pa11y
+      run: npm install pa11y-ci pa11y-ci-reporter-html -g
+
+    - name: Run Pa11y and pipe all output to file
+      continue-on-error: true
+      id: run-pa11y
+      run: |
+        find .docs/ -type f -name "index.html" -exec pa11y-ci {} 2>&1 + | tee ./reports/pa11y.txt
+        echo "message=$(cat ./reports/pa11y.txt)" >> $GITHUB_OUTPUT
+
+    - id: artifact-upload-step
+      uses: actions/upload-artifact@v4
+      if: inputs.upload_report == true
+      with:
+        name: Pa11y accessibility report
+        path: ./reports/pa11y/
+
+    - id: artifact-html-true
+      name: Pipe artifact link string to environment variable if uploading report
+      if: inputs.upload_report == true && inputs.allow_pr_comment == true
+      run: |
+        echo "ARTIFACT_HTML=\nFull output: <${{ steps.artifact-upload-step.outputs.artifact-url }}>" >> "$GITHUB_ENV"
+
+    - id: artifact-html-false
+      name: Pipe empty string to environment variable if not uploading report
+      if: inputs.upload_report == false && inputs.allow_pr_comment == true
+      run: |
+        echo "ARTIFACT_HTML=''" >> "$GITHUB_ENV"
+
+    - name: Pipe summary lines of Pa11y output to an environment variable.
+      if: inputs.allow_pr_comment == true
+      run: |
+        {
+          LINES=$(find .docs/ -type f -name "index.html" | wc -l)
+          echo 'PA11Y_OUTPUT<<EOF'
+          cat pa11y-output.txt | head -n $((LINES + 1))
+          echo EOF
+        } >> "$GITHUB_ENV"
+
+    - name: Comment PR with execution number
+      if: inputs.allow_pr_comment == true
+      uses: thollander/actions-comment-pull-request@v2
+      with:
+        message: |
+          ## Documentation accessibility test results (using Pa11y)
+          ${{ env.ARTIFACT_HTML }}
+
+          <details><summary>Click for summary</summary>
+
+          ```${{ env.PA11Y_OUTPUT }}```
+
+          </details>
+        pr_number: ${{ github.event.number }}
+        comment_tag: execution

--- a/.github/workflows/docs-a11y.yml
+++ b/.github/workflows/docs-a11y.yml
@@ -83,7 +83,7 @@ jobs:
         {
           LINES=$(find .docs/ -type f -name "index.html" | wc -l)
           echo 'PA11Y_OUTPUT<<EOF'
-          cat pa11y-output.txt | head -n $((LINES + 1))
+          cat pa11y-output.txt | head -n $((LINES + 3))
           echo EOF
         } >> "$GITHUB_ENV"
 

--- a/.github/workflows/docs-a11y.yml
+++ b/.github/workflows/docs-a11y.yml
@@ -72,7 +72,7 @@ jobs:
       name: Pipe artifact link string to environment variable if uploading report
       if: inputs.upload_report == true && inputs.allow_pr_comment == true
       run: |
-        echo "ARTIFACT_HTML=\nFull output: <${{ steps.artifact-upload-step.outputs.artifact-url }}>" >> "$GITHUB_ENV"
+        echo "ARTIFACT_HTML=Full output: <${{ steps.artifact-upload-step.outputs.artifact-url }}>" >> "$GITHUB_ENV"
 
     - id: artifact-html-false
       name: Pipe empty string to environment variable if not uploading report
@@ -96,6 +96,7 @@ jobs:
       with:
         message: |
           ## Documentation accessibility test results (using Pa11y)
+
           ${{ env.ARTIFACT_HTML }}
 
           <details><summary>Click for summary</summary>

--- a/.github/workflows/docs-a11y.yml
+++ b/.github/workflows/docs-a11y.yml
@@ -97,7 +97,9 @@ jobs:
 
           <details><summary>Click for summary</summary>
 
-          ```${{ env.PA11Y_OUTPUT }}```
+          ``` shell
+          ${{ env.PA11Y_OUTPUT }}
+          ```
 
           </details>
 

--- a/.github/workflows/docs-a11y.yml
+++ b/.github/workflows/docs-a11y.yml
@@ -78,7 +78,7 @@ jobs:
       name: Pipe empty string to environment variable if not uploading report
       if: inputs.upload_report == false && inputs.allow_pr_comment == true
       run: |
-        echo "ARTIFACT_HTML=''" >> "$GITHUB_ENV"
+        echo "ARTIFACT_HTML=" >> "$GITHUB_ENV"
 
     - name: Pipe summary lines of Pa11y output to an environment variable.
       if: inputs.allow_pr_comment == true
@@ -96,7 +96,6 @@ jobs:
       with:
         message: |
           ## Documentation accessibility test results (using Pa11y)
-
           ${{ env.ARTIFACT_HTML }}
 
           <details><summary>Click for summary</summary>
@@ -104,5 +103,6 @@ jobs:
           ```${{ env.PA11Y_OUTPUT }}```
 
           </details>
+
         pr_number: ${{ github.event.number }}
         comment_tag: execution

--- a/.github/workflows/docs-a11y.yml
+++ b/.github/workflows/docs-a11y.yml
@@ -24,7 +24,7 @@ jobs:
   docs-accessibility:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: mamba-org/setup-micromamba@v1
       with:
         micromamba-version: latest
@@ -55,11 +55,8 @@ jobs:
       run: npm install pa11y-ci pa11y-ci-reporter-html -g
 
     - name: Run Pa11y and pipe all output to file
-      continue-on-error: true
       id: run-pa11y
-      run: |
-        find .docs/ -type f -name "index.html" -exec pa11y-ci {} 2>&1 + | tee ./reports/pa11y.txt
-        echo "message=$(cat ./reports/pa11y.txt)" >> $GITHUB_OUTPUT
+      run: find .docs/ -type f -name "index.html" -exec pa11y-ci {} 2>&1 + | tee pa11y-output.txt
 
     - id: artifact-upload-step
       uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,14 +25,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - README
 
 - Reusable workflows for:
-    - Upload package to AWS
-    - Build a conda package
-    - Upload a conda package
-    - Deploy documentation
-    - Run tests on python package
-    - Run memory profiling tests on python package
-    - Notify about action success / failure on a slack channel
-    - Check whether project and parent template have diverged
+  - Upload package to AWS
+  - Build a conda package
+  - Upload a conda package
+  - Deploy documentation
+  - Run tests on python package
+  - Run memory profiling tests on python package
+  - Notify about action success / failure on a slack channel
+  - Check whether project and parent template have diverged
+  - Check accessibility of documentation
 
 - GitHub Action to validate the reusable workflows themselves
 - Optional `image-tags` input parameter added to the AWS Upload workflow ([#19](https://github.com/arup-group/actions-city-modelling-lab/issues/19))

--- a/README.md
+++ b/README.md
@@ -226,6 +226,20 @@ _Inputs_:
 
 _Required secrets_: None
 
+### Check accessibility of documentation
+
+_URL_: `arup-group/actions-city-modelling-lab/.github/workflows/docs-a11y.yml`
+
+_description_: Check accessibility (a11y) of built documentation using [pa11y-ci](https://github.com/pa11y/pa11y-ci).
+
+_Inputs_:
+
+- upload_report (optional, default=true): If true, upload a workflow artifact containing a full HTML accessibility report.
+- allow_pr_comment (optional, default=true): If true, allow a bot to leave a PR comment with a summary of the accessibility report (including a link to the HTML report if `upload_report` is _true_).
+- notebook_kernel: If jupyter notebooks are included in the docs, specify the kernel name they expect, e.g. the package name.
+
+_Required secrets_: None
+
 ### Run tests on python package
 
 _URL_: `arup-group/actions-city-modelling-lab/.github/workflows/python-install-lint-test.yml`


### PR DESCRIPTION
Checks documentation HTML files for accessibility issues using pa11y-ci. Will report the result of the check as a PR comment and as a navigable HTML report (both are configurable).