### PR TITLE
Setup micromamba to miniconda

### DIFF
--- a/.github/actions/create-mamba-env/action.yml
+++ b/.github/actions/create-mamba-env/action.yml
@@ -13,7 +13,7 @@ inputs:
   cache_mamba_env:
     description: "If true, cache the mamba environment for speedier CI"
     required: false
-    default: true
+    default: "true"
   cache_refresh_time_format:
     description: >-
       The time format to extract from the current date with which a cache refresh will be forced even if nothing has changed in the environment name.
@@ -42,7 +42,7 @@ runs:
 
     - name: Cache Mamba env
       id: cache
-      if: ${{ inputs.cache_mamba_env }} == true
+      if: ${{ inputs.cache_mamba_env }} == 'true'
       uses: actions/cache@v3
       with:
         path: ${{ env.CONDA }}/envs

--- a/.github/actions/create-mamba-env/action.yml
+++ b/.github/actions/create-mamba-env/action.yml
@@ -53,12 +53,12 @@ runs:
       if: steps.cache.outputs.cache-hit != 'true'
       shell: bash
       run:
-        mamba env create --yes
+        mamba create --yes
         -c city-modelling-lab
         -n ${{ inputs.env_name }}
         ${{ inputs.additional_mamba_args }}
-        -f requirements/base.txt
-        -f requirements/dev.txt
+        --file requirements/base.txt
+        --file requirements/dev.txt
         ruff
 
     - name: Install package

--- a/.github/actions/create-mamba-env/action.yml
+++ b/.github/actions/create-mamba-env/action.yml
@@ -63,4 +63,4 @@ runs:
 
     - name: Install package
       shell: bash
-      run: pip install --no-dependencies -e .
+      run: mamba run -n ${{ inputs.env_name }} pip install --no-dependencies -e .

--- a/.github/actions/create-mamba-env/action.yml
+++ b/.github/actions/create-mamba-env/action.yml
@@ -3,21 +3,17 @@ inputs:
   py3version:
     description: "Minor version of Python version 3 to run the test on (e.g. `11` for python v3.11)"
     required: true
-    type: string
   env_name:
     description: "Name of the Mamba environment. If it matches a name of a cached environment in the caller repository, that cache will be used."
     required: true
-    type: string
   additional_mamba_args:
     description: "Any additional arguments to pass to micromamba when creating the python environment"
     required: false
     default: ""
-    type: string
   cache_mamba_env:
     description: "If true, cache the mamba environment for speedier CI"
     required: false
     default: true
-    type: boolean
   cache_refresh_time_format:
     description: >-
       The time format to extract from the current date with which a cache refresh will be forced even if nothing has changed in the environment name.
@@ -25,7 +21,6 @@ inputs:
       Format options are '%Y' (year), '%m' (month) and '%d' (day).
     required: false
     default: "+%Y%m"
-    type: string
 runs:
   using: "composite" #
   steps:

--- a/.github/actions/create-mamba-env/action.yml
+++ b/.github/actions/create-mamba-env/action.yml
@@ -1,4 +1,5 @@
 name: "Create a mamba environment"
+description: "Steps to create mamba environment with all required dependencies and the project itself installed (via pip)."
 inputs:
   py3version:
     description: "Minor version of Python version 3 to run the test on (e.g. `11` for python v3.11)"

--- a/.github/actions/create-mamba-env/action.yml
+++ b/.github/actions/create-mamba-env/action.yml
@@ -1,0 +1,67 @@
+name: "Create a mamba environment"
+inputs:
+  py3version:
+    description: "Minor version of Python version 3 to run the test on (e.g. `11` for python v3.11)"
+    required: true
+    type: string
+  env_name:
+    description: "Name of the Mamba environment. If it matches a name of a cached environment in the caller repository, that cache will be used."
+    required: true
+    type: string
+  additional_mamba_args:
+    description: "Any additional arguments to pass to micromamba when creating the python environment"
+    required: false
+    default: ""
+    type: string
+  cache_mamba_env:
+    description: "If true, cache the mamba environment for speedier CI"
+    required: false
+    default: true
+    type: boolean
+  cache_refresh_time_format:
+    description: >-
+      The time format to extract from the current date with which a cache refresh will be forced even if nothing has changed in the environment name.
+      E.g. '+%Y%m' forces a cache reset every month.
+      Format options are '%Y' (year), '%m' (month) and '%d' (day).
+    required: false
+    default: "+%Y%m"
+    type: string
+runs:
+  using: "composite" #
+  steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup Mambaforge
+      uses: conda-incubator/setup-miniconda@v3
+      with:
+        miniforge-variant: Mambaforge
+        miniforge-version: latest
+        activate-environment: ${{ inputs.env_name }}
+        use-mamba: true
+        python-version: 3.${{ inputs.py3version }}
+
+    - name: Get Date
+      id: get-refresh-timestamp
+      run: echo "timestamp=$(/bin/date -u ${{ inputs.cache_refresh_time_format }})" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - name: Cache Mamba env
+      id: cache
+      if: ${{ inputs.cache_mamba_env }} == true
+      uses: actions/cache@v3
+      with:
+        path: ${{ env.CONDA }}/envs
+        key: ${{ steps.get-refresh-timestamp.outputs.timestamp }}-${{ inputs.env_name }}
+
+    - name: Update environment
+      run:
+        mamba env update -n ${{ inputs.env_name }}
+        ${{ inputs.additional_mamba_args }}
+        -f requirements/base.txt
+        -f requirements/dev.txt
+        -c city-modelling-lab
+        ruff
+      if: steps.cache.outputs.cache-hit != 'true'
+
+    - name: Install package
+      run: pip install --no-dependencies -e .

--- a/.github/actions/create-mamba-env/action.yml
+++ b/.github/actions/create-mamba-env/action.yml
@@ -56,10 +56,10 @@ runs:
         mamba update
         -c city-modelling-lab
         -n ${{ inputs.env_name }}
+        ruff
         ${{ inputs.additional_mamba_args }}
         --file requirements/base.txt
         --file requirements/dev.txt
-        ruff
 
     - name: Install package
       shell: bash

--- a/.github/actions/create-mamba-env/action.yml
+++ b/.github/actions/create-mamba-env/action.yml
@@ -53,7 +53,7 @@ runs:
       if: steps.cache.outputs.cache-hit != 'true'
       shell: bash
       run:
-        mamba create --yes
+        mamba update
         -c city-modelling-lab
         -n ${{ inputs.env_name }}
         ${{ inputs.additional_mamba_args }}

--- a/.github/actions/create-mamba-env/action.yml
+++ b/.github/actions/create-mamba-env/action.yml
@@ -53,7 +53,7 @@ runs:
       if: steps.cache.outputs.cache-hit != 'true'
       shell: bash
       run:
-        mamba env update
+        mamba env create --yes
         -c city-modelling-lab
         -n ${{ inputs.env_name }}
         ${{ inputs.additional_mamba_args }}

--- a/.github/actions/create-mamba-env/action.yml
+++ b/.github/actions/create-mamba-env/action.yml
@@ -54,6 +54,8 @@ runs:
         key: ${{ steps.get-refresh-timestamp.outputs.timestamp }}-${{ inputs.env_name }}
 
     - name: Update environment
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
       run:
         mamba env update -n ${{ inputs.env_name }}
         ${{ inputs.additional_mamba_args }}
@@ -61,7 +63,7 @@ runs:
         -f requirements/dev.txt
         -c city-modelling-lab
         ruff
-      if: steps.cache.outputs.cache-hit != 'true'
 
     - name: Install package
+      shell: bash
       run: pip install --no-dependencies -e .

--- a/.github/actions/create-mamba-env/action.yml
+++ b/.github/actions/create-mamba-env/action.yml
@@ -27,12 +27,17 @@ runs:
   steps:
     - uses: actions/checkout@v4
 
+    - name: Get hash for environment name
+      id: get-env-hash
+      run: echo "hash=${{ github.event.repository.name }}-${{ inputs.env_name }}-${{ hashFiles('requirements/base.txt', 'requirements/dev.txt') }}" >> $GITHUB_OUTPUT
+
+      shell: bash
     - name: Setup Mambaforge
       uses: conda-incubator/setup-miniconda@v3
       with:
         miniforge-variant: Mambaforge
         miniforge-version: latest
-        activate-environment: ${{ inputs.env_name }}
+        activate-environment: ${{ steps.get-env-hash.outputs.hash }}
         use-mamba: true
         python-version: 3.${{ inputs.py3version }}
 
@@ -47,7 +52,7 @@ runs:
       uses: actions/cache@v3
       with:
         path: ${{ env.CONDA }}/envs
-        key: ${{ steps.get-refresh-timestamp.outputs.timestamp }}-${{ inputs.env_name }}
+        key: ${{ steps.get-refresh-timestamp.outputs.timestamp }}-${{ steps.get-env-hash.outputs.hash }}
 
     - name: Update environment
       if: steps.cache.outputs.cache-hit != 'true'
@@ -55,7 +60,7 @@ runs:
       run:
         mamba update
         -c city-modelling-lab
-        -n ${{ inputs.env_name }}
+        -n ${{ steps.get-env-hash.outputs.hash }}
         ruff
         ${{ inputs.additional_mamba_args }}
         --file requirements/base.txt
@@ -63,4 +68,4 @@ runs:
 
     - name: Install package
       shell: bash
-      run: mamba run -n ${{ inputs.env_name }} pip install --no-dependencies -e .
+      run: mamba run -n ${{ steps.get-env-hash.outputs.hash }} pip install --no-dependencies -e .

--- a/.github/actions/create-mamba-env/action.yml
+++ b/.github/actions/create-mamba-env/action.yml
@@ -57,11 +57,12 @@ runs:
       if: steps.cache.outputs.cache-hit != 'true'
       shell: bash
       run:
-        mamba env update -n ${{ inputs.env_name }}
+        mamba env update
+        -c city-modelling-lab
+        -n ${{ inputs.env_name }}
         ${{ inputs.additional_mamba_args }}
         -f requirements/base.txt
         -f requirements/dev.txt
-        -c city-modelling-lab
         ruff
 
     - name: Install package

--- a/.github/workflows/docs-a11y.yml
+++ b/.github/workflows/docs-a11y.yml
@@ -41,7 +41,7 @@ jobs:
         py3version: ${{ inputs.py3version }}
         env_name: ${{ github.event.repository.name }}-docs-${{ hashFiles('requirements/base.txt') }}-${{ hashFiles('requirements/dev.txt') }}
         additional_mamba_args: ${{ inputs.additional_mamba_args }}
-        cache_mamba_env: true
+        cache_mamba_env: "true"
 
     - name: install jupyter kernel
       if: inputs.notebook_kernel != ''

--- a/.github/workflows/docs-a11y.yml
+++ b/.github/workflows/docs-a11y.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: arup-group/actions-city-modelling-lab/.github/actions/create-mamba-env@setup-micromamba-to-miniconda
+    - uses: arup-group/actions-city-modelling-lab/.github/actions/create-mamba-env@main
       with:
         py3version: ${{ inputs.py3version }}
         env_name: docs

--- a/.github/workflows/docs-a11y.yml
+++ b/.github/workflows/docs-a11y.yml
@@ -22,8 +22,9 @@ on:
         type: string
       py3version:
         description: "Minor version of Python version 3 to run the test on (e.g. `11` for python v3.11)"
-        required: true
+        required: false
         type: string
+        default: "11"
 
 defaults:
   run:

--- a/.github/workflows/docs-a11y.yml
+++ b/.github/workflows/docs-a11y.yml
@@ -39,7 +39,7 @@ jobs:
     - uses: arup-group/actions-city-modelling-lab/.github/actions/create-mamba-env@setup-micromamba-to-miniconda
       with:
         py3version: ${{ inputs.py3version }}
-        env_name: ${{ github.event.repository.name }}-docs-${{ hashFiles('requirements/base.txt') }}-${{ hashFiles('requirements/dev.txt') }}
+        env_name: docs
         additional_mamba_args: ${{ inputs.additional_mamba_args }}
         cache_mamba_env: "true"
 

--- a/.github/workflows/docs-a11y.yml
+++ b/.github/workflows/docs-a11y.yml
@@ -15,6 +15,15 @@ on:
         description: "If jupyter notebooks are included in the docs, specify the kernel name they expect, e.g. the package name"
         required: false
         type: string
+      additional_mamba_args:
+        description: "Any additional arguments to pass to micromamba when creating the python environment"
+        required: false
+        default: ""
+        type: string
+      py3version:
+        description: "Minor version of Python version 3 to run the test on (e.g. `11` for python v3.11)"
+        required: true
+        type: string
 
 defaults:
   run:
@@ -31,9 +40,10 @@ jobs:
         environment-name: ${{ github.event.repository.name }}-docs-${{ hashFiles('requirements/dev.txt') }}
         environment-file: requirements/base.txt
         create-args: >-
+            ${{ inputs.additional_mamba_args }}
             -c city-modelling-lab
             -f requirements/dev.txt
-            python=3.11
+            python=3.${{ inputs.py3version }}
         post-cleanup: all
         cache-environment: true
 

--- a/.github/workflows/docs-a11y.yml
+++ b/.github/workflows/docs-a11y.yml
@@ -35,21 +35,13 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v4
-    - uses: mamba-org/setup-micromamba@v1
-      with:
-        micromamba-version: latest
-        environment-name: ${{ github.event.repository.name }}-docs-${{ hashFiles('requirements/dev.txt') }}
-        environment-file: requirements/base.txt
-        create-args: >-
-            ${{ inputs.additional_mamba_args }}
-            -c city-modelling-lab
-            -f requirements/dev.txt
-            python=3.${{ inputs.py3version }}
-        post-cleanup: all
-        cache-environment: true
 
-    - name: Install package
-      run: pip install --no-dependencies -e .
+    - uses: arup-group/actions-city-modelling-lab/.github/actions/create-mamba-env@setup-micromamba-to-miniconda
+      with:
+        py3version: ${{ inputs.py3version }}
+        env_name: ${{ github.event.repository.name }}-docs-${{ hashFiles('requirements/base.txt') }}-${{ hashFiles('requirements/dev.txt') }}
+        additional_mamba_args: ${{ inputs.additional_mamba_args }}
+        cache_mamba_env: true
 
     - name: install jupyter kernel
       if: inputs.notebook_kernel != ''

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -21,8 +21,9 @@ on:
         type: string
       py3version:
         description: "Minor version of Python version 3 to run the test on (e.g. `11` for python v3.11)"
-        required: true
+        required: false
         type: string
+        default: "11"
 
 defaults:
   run:

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -45,7 +45,7 @@ jobs:
       with:
         fetch-depth: 0  # used to build docs into the gh-pages branch without losing branch history. See https://github.com/jimporter/mike/issues/49
 
-    - uses: arup-group/actions-city-modelling-lab/.github/actions/create-mamba-env@setup-micromamba-to-miniconda
+    - uses: arup-group/actions-city-modelling-lab/.github/actions/create-mamba-env@main
       with:
         py3version: ${{ inputs.py3version }}
         env_name: docs

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -50,7 +50,7 @@ jobs:
         py3version: ${{ inputs.py3version }}
         env_name: ${{ github.event.repository.name }}-docs-${{ hashFiles('requirements/base.txt') }}-${{ hashFiles('requirements/dev.txt') }}
         additional_mamba_args: ${{ inputs.additional_mamba_args }}
-        cache_mamba_env: true
+        cache_mamba_env: "true"
 
     - name: install jupyter kernel
       if: inputs.notebook_kernel != ''

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -14,6 +14,15 @@ on:
         description: "If jupyter notebooks are included in the docs, specify the kernel name they expect, e.g. the package name"
         required: false
         type: string
+      additional_mamba_args:
+        description: "Any additional arguments to pass to micromamba when creating the python environment"
+        required: false
+        default: ""
+        type: string
+      py3version:
+        description: "Minor version of Python version 3 to run the test on (e.g. `11` for python v3.11)"
+        required: true
+        type: string
 
 defaults:
   run:
@@ -41,9 +50,10 @@ jobs:
         environment-name: ${{ github.event.repository.name }}-docs-${{ hashFiles('requirements/dev.txt') }}
         environment-file: requirements/base.txt
         create-args: >-
+            ${{ inputs.additional_mamba_args }}
             -c city-modelling-lab
             -f requirements/dev.txt
-            python=3.11
+            python=3.${{ inputs.py3version }}
         post-cleanup: all
         cache-environment: true
 

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -48,7 +48,7 @@ jobs:
     - uses: arup-group/actions-city-modelling-lab/.github/actions/create-mamba-env@setup-micromamba-to-miniconda
       with:
         py3version: ${{ inputs.py3version }}
-        env_name: ${{ github.event.repository.name }}-docs-${{ hashFiles('requirements/base.txt') }}-${{ hashFiles('requirements/dev.txt') }}
+        env_name: docs
         additional_mamba_args: ${{ inputs.additional_mamba_args }}
         cache_mamba_env: "true"
 

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -45,21 +45,12 @@ jobs:
       with:
         fetch-depth: 0  # used to build docs into the gh-pages branch without losing branch history. See https://github.com/jimporter/mike/issues/49
 
-    - uses: mamba-org/setup-micromamba@v1
+    - uses: arup-group/actions-city-modelling-lab/.github/actions/create-mamba-env@setup-micromamba-to-miniconda
       with:
-        micromamba-version: latest
-        environment-name: ${{ github.event.repository.name }}-docs-${{ hashFiles('requirements/dev.txt') }}
-        environment-file: requirements/base.txt
-        create-args: >-
-            ${{ inputs.additional_mamba_args }}
-            -c city-modelling-lab
-            -f requirements/dev.txt
-            python=3.${{ inputs.py3version }}
-        post-cleanup: all
-        cache-environment: true
-
-    - name: Install package
-      run: pip install --no-dependencies -e .
+        py3version: ${{ inputs.py3version }}
+        env_name: ${{ github.event.repository.name }}-docs-${{ hashFiles('requirements/base.txt') }}-${{ hashFiles('requirements/dev.txt') }}
+        additional_mamba_args: ${{ inputs.additional_mamba_args }}
+        cache_mamba_env: true
 
     - name: install jupyter kernel
       if: inputs.notebook_kernel != ''

--- a/.github/workflows/python-install-lint-test.yml
+++ b/.github/workflows/python-install-lint-test.yml
@@ -68,7 +68,7 @@ jobs:
         py3version: ${{ inputs.py3version }}
         env_name: ${{ env.MAMBAENVNAME }}
         additional_mamba_args: ${{ inputs.additional_mamba_args }}
-        cache_mamba_env: ${{ inputs.cache_mamba_env }}
+        cache_mamba_env: "${{ inputs.cache_mamba_env }}"
 
     - name: Install jupyter kernel
       if: inputs.notebook_kernel != ''

--- a/.github/workflows/python-install-lint-test.yml
+++ b/.github/workflows/python-install-lint-test.yml
@@ -61,7 +61,7 @@ jobs:
 
     - name: Create Mamba environment name based on OS and python version
       if: inputs.mamba_env_name == ''
-      run: echo "MAMBAENVNAME=${{ github.event.repository.name }}-${{ inputs.os }}-3${{ inputs.py3version }}-${{ hashFiles('requirements/base.txt') }}-${{ hashFiles('requirements/dev.txt') }}" >> $GITHUB_ENV
+      run: echo "MAMBAENVNAME=${{ inputs.os }}-3${{ inputs.py3version }}" >> $GITHUB_ENV
 
     - uses: arup-group/actions-city-modelling-lab/.github/actions/create-mamba-env@setup-micromamba-to-miniconda
       with:

--- a/.github/workflows/python-install-lint-test.yml
+++ b/.github/workflows/python-install-lint-test.yml
@@ -63,7 +63,7 @@ jobs:
       if: inputs.mamba_env_name == ''
       run: echo "MAMBAENVNAME=${{ inputs.os }}-3${{ inputs.py3version }}" >> $GITHUB_ENV
 
-    - uses: arup-group/actions-city-modelling-lab/.github/actions/create-mamba-env@setup-micromamba-to-miniconda
+    - uses: arup-group/actions-city-modelling-lab/.github/actions/create-mamba-env@main
       with:
         py3version: ${{ inputs.py3version }}
         env_name: ${{ env.MAMBAENVNAME }}

--- a/.github/workflows/python-install-lint-test.yml
+++ b/.github/workflows/python-install-lint-test.yml
@@ -53,7 +53,7 @@ jobs:
   test:
     runs-on: ${{ inputs.os }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Use supplied Mamba environment name
       if: inputs.mamba_env_name != ''
@@ -61,24 +61,15 @@ jobs:
 
     - name: Create Mamba environment name based on OS and python version
       if: inputs.mamba_env_name == ''
-      run: echo "MAMBAENVNAME=${{ inputs.os }}-3${{ inputs.py3version }}-${{ hashFiles('requirements/dev.txt') }}" >> $GITHUB_ENV
+      run: echo "MAMBAENVNAME=${{ github.event.repository.name }}-${{ inputs.os }}-3${{ inputs.py3version }}-${{ hashFiles('requirements/base.txt') }}-${{ hashFiles('requirements/dev.txt') }}" >> $GITHUB_ENV
 
-    - uses: mamba-org/setup-micromamba@v1
+    - uses: arup-group/actions-city-modelling-lab/.github/actions/create-mamba-env@setup-micromamba-to-miniconda
       with:
-        micromamba-version: latest
-        environment-name: ${{ github.event.repository.name }}-${{ env.MAMBAENVNAME }}
-        environment-file: requirements/base.txt
-        create-args: >-
-          ${{ inputs.additional_mamba_args }}
-          -c city-modelling-lab
-          -f requirements/dev.txt
-          ruff
-          python=3.${{ inputs.py3version }}
-        post-cleanup: all
-        cache-environment: ${{ inputs.cache_mamba_env }}
-
-    - name: Install package
-      run: pip install --no-dependencies -e .
+        os: ${{ inputs.os }}
+        py3version: ${{ inputs.py3version }}
+        env_name: ${{ env.MAMBAENVNAME }}
+        additional_mamba_args: ${{ inputs.additional_mamba_args }}
+        cache_mamba_env: ${{ inputs.cache_mamba_env }}
 
     - name: Install jupyter kernel
       if: inputs.notebook_kernel != ''

--- a/.github/workflows/python-install-lint-test.yml
+++ b/.github/workflows/python-install-lint-test.yml
@@ -65,7 +65,6 @@ jobs:
 
     - uses: arup-group/actions-city-modelling-lab/.github/actions/create-mamba-env@setup-micromamba-to-miniconda
       with:
-        os: ${{ inputs.os }}
         py3version: ${{ inputs.py3version }}
         env_name: ${{ env.MAMBAENVNAME }}
         additional_mamba_args: ${{ inputs.additional_mamba_args }}

--- a/.github/workflows/python-memory-profile.yml
+++ b/.github/workflows/python-memory-profile.yml
@@ -32,7 +32,7 @@ jobs:
           py3version: ${{ inputs.py3version }}
           env_name: ${{ github.event.repository.name }}-profiling-${{ hashFiles('requirements/base.txt') }}-${{ hashFiles('requirements/dev.txt') }}
           additional_mamba_args: memray=1.9 pytest-memray=1.5 ${{ inputs.additional_mamba_args }}
-          cache_mamba_env: true
+          cache_mamba_env: "true"
 
       - name: Run memory and time profiling test
         run: |

--- a/.github/workflows/python-memory-profile.yml
+++ b/.github/workflows/python-memory-profile.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: arup-group/actions-city-modelling-lab/.github/actions/create-mamba-env@setup-micromamba-to-miniconda
+      - uses: arup-group/actions-city-modelling-lab/.github/actions/create-mamba-env@main
         with:
           py3version: ${{ inputs.py3version }}
           env_name: profiling

--- a/.github/workflows/python-memory-profile.yml
+++ b/.github/workflows/python-memory-profile.yml
@@ -26,23 +26,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: mamba-org/setup-micromamba@v1
-        with:
-          micromamba-version: latest
-          environment-name: ${{ github.event.repository.name }}-ubuntu-latest-3${{ inputs.py3version }}-profiling-${{ hashFiles('requirements/dev.txt') }}
-          environment-file: requirements/base.txt
-          create-args: >-
-            ${{ inputs.additional_mamba_args }}
-            -c city-modelling-lab
-            -f requirements/dev.txt
-            python=3.${{ inputs.py3version }}
-            memray=1.9
-            pytest-memray=1.5
-          post-cleanup: all
-          cache-environment: true
 
-      - name: Install package
-        run: pip install --no-dependencies .
+      - uses: arup-group/actions-city-modelling-lab/.github/actions/create-mamba-env@setup-micromamba-to-miniconda
+        with:
+          py3version: ${{ inputs.py3version }}
+          env_name: ${{ github.event.repository.name }}-profiling-${{ hashFiles('requirements/base.txt') }}-${{ hashFiles('requirements/dev.txt') }}
+          additional_mamba_args: memray=1.9 pytest-memray=1.5 ${{ inputs.additional_mamba_args }}
+          cache_mamba_env: true
 
       - name: Run memory and time profiling test
         run: |

--- a/.github/workflows/python-memory-profile.yml
+++ b/.github/workflows/python-memory-profile.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: arup-group/actions-city-modelling-lab/.github/actions/create-mamba-env@setup-micromamba-to-miniconda
         with:
           py3version: ${{ inputs.py3version }}
-          env_name: ${{ github.event.repository.name }}-profiling-${{ hashFiles('requirements/base.txt') }}-${{ hashFiles('requirements/dev.txt') }}
+          env_name: profiling
           additional_mamba_args:
             memray=1.9
             pytest-memray=1.5

--- a/.github/workflows/python-memory-profile.yml
+++ b/.github/workflows/python-memory-profile.yml
@@ -31,7 +31,10 @@ jobs:
         with:
           py3version: ${{ inputs.py3version }}
           env_name: ${{ github.event.repository.name }}-profiling-${{ hashFiles('requirements/base.txt') }}-${{ hashFiles('requirements/dev.txt') }}
-          additional_mamba_args: memray=1.9 pytest-memray=1.5 ${{ inputs.additional_mamba_args }}
+          additional_mamba_args:
+            memray=1.9
+            pytest-memray=1.5
+            ${{ inputs.additional_mamba_args }}
           cache_mamba_env: "true"
 
       - name: Run memory and time profiling test

--- a/.github/workflows/validate-reusable-workflows.yml
+++ b/.github/workflows/validate-reusable-workflows.yml
@@ -27,4 +27,7 @@ jobs:
           tool_versions: action-validator 0.5.3
 
       - name: Lint Actions
+        run: action-validator --verbose .github/actions/**/*.y*ml
+
+      - name: Lint Workflows
         run: action-validator --verbose .github/workflows/*.y*ml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Moved to `conda-incubator/setup-miniconda` instead of `mamba-org/setup-micromamba` where we would benefit from having `mamba`/`conda` available on the runner PATH (#26).
+
+### Added
+
+- Composite action for building a project-specific conda environment, used across reusable workflows but also available for direct use as a step in other projects (#26).
+
 ## [v1.0.0] - 2024-07-12
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ _Inputs_:
    `update_latest` will build the docs and use it to update the `develop` version of your `gh-pages` branch, assuming the alias `latest` links to the named version `develop`.
    `update_stable` will build the docs and use it to add a new version of your docs on `gh-pages` branch and will update the alias `stable` to point at this version.
 - notebook_kernel: If jupyter notebooks are included in the docs, specify the kernel name they expect, e.g. the package name.
-- py3version: Minor version of Python version 3 to run the test on (e.g. `11` for python v3.11).
+- py3version (optional, default="11"): Minor version of Python version 3 to run the test on (e.g. `11` for python v3.11).
 - additional_mamba_args (optional, default=""): Any additional arguments to pass to micromamba when creating the python environment.
 
 _Required secrets_: None
@@ -239,7 +239,7 @@ _Inputs_:
 - upload_report (optional, default=true): If true, upload a workflow artifact containing a full HTML accessibility report.
 - allow_pr_comment (optional, default=true): If true, allow a bot to leave a PR comment with a summary of the accessibility report (including a link to the HTML report if `upload_report` is _true_).
 - notebook_kernel: If jupyter notebooks are included in the docs, specify the kernel name they expect, e.g. the package name.
-- py3version: Minor version of Python version 3 to run the test on (e.g. `11` for python v3.11).
+- py3version (optional, default="11"): Minor version of Python version 3 to run the test on (e.g. `11` for python v3.11).
 - additional_mamba_args (optional, default=""): Any additional arguments to pass to micromamba when creating the python environment.
 
 _Required secrets_: None

--- a/README.md
+++ b/README.md
@@ -223,6 +223,8 @@ _Inputs_:
    `update_latest` will build the docs and use it to update the `develop` version of your `gh-pages` branch, assuming the alias `latest` links to the named version `develop`.
    `update_stable` will build the docs and use it to add a new version of your docs on `gh-pages` branch and will update the alias `stable` to point at this version.
 - notebook_kernel: If jupyter notebooks are included in the docs, specify the kernel name they expect, e.g. the package name.
+- py3version: Minor version of Python version 3 to run the test on (e.g. `11` for python v3.11).
+- additional_mamba_args (optional, default=""): Any additional arguments to pass to micromamba when creating the python environment.
 
 _Required secrets_: None
 
@@ -237,6 +239,8 @@ _Inputs_:
 - upload_report (optional, default=true): If true, upload a workflow artifact containing a full HTML accessibility report.
 - allow_pr_comment (optional, default=true): If true, allow a bot to leave a PR comment with a summary of the accessibility report (including a link to the HTML report if `upload_report` is _true_).
 - notebook_kernel: If jupyter notebooks are included in the docs, specify the kernel name they expect, e.g. the package name.
+- py3version: Minor version of Python version 3 to run the test on (e.g. `11` for python v3.11).
+- additional_mamba_args (optional, default=""): Any additional arguments to pass to micromamba when creating the python environment.
 
 _Required secrets_: None
 


### PR DESCRIPTION
Moving to using `miniconda` rather than `micromamba` wherever we are installing the development environment of the "calling" repository. This is necessary so that we have `mamba`/`conda` on PATH, which you don't get with `micromamba`. 

It does bloat the jobs slightly more, but environment caching is in place to hopefully mitigate that.

I've also reduced code duplication, but at the cost of a slightly circular dependency. The "composite action" containing all the stuff to create a new environment is now in `actions` and is called by its URL from the reusable workflows. This is working just fine in my [test repository jobs](https://github.com/brynpickering/python_boilerplate/pull/8) but does mean that the composite action version needs to be updated from this branch name to `main` _before_ merging this PR (I had to use this branch name so the whole pipeline works in my test repo).
