### PR TITLE
Update mamba install method; add pwd env cache directory

### DIFF
--- a/.github/actions/create-mamba-env/action.yml
+++ b/.github/actions/create-mamba-env/action.yml
@@ -41,7 +41,7 @@ runs:
       with:
         miniforge-variant: Mambaforge
         miniforge-version: latest
-        activate-environment: ${{ github.workspace }}/.envs/${{ steps.get-env-hash.outputs.hash }}
+        activate-environment: .envs/${{ steps.get-env-hash.outputs.hash }}
         use-mamba: true
         python-version: 3.${{ inputs.py3version }}
 
@@ -56,7 +56,7 @@ runs:
       uses: actions/cache@v3
       with:
         path: |
-          ${{ github.workspace }}/.envs
+          .envs
           ${{ inputs.additional_cache_dir }}
         key: ${{ steps.get-refresh-timestamp.outputs.timestamp }}-${{ steps.get-env-hash.outputs.hash }}
 
@@ -66,7 +66,7 @@ runs:
       run:
         mamba update
         -c city-modelling-lab
-        -p '${{ github.workspace }}/.envs/${{ steps.get-env-hash.outputs.hash }}'
+        -p .envs/${{ steps.get-env-hash.outputs.hash }}
         ruff
         ${{ inputs.additional_mamba_args }}
         --file requirements/base.txt
@@ -74,4 +74,4 @@ runs:
 
     - name: Install package
       shell: bash
-      run: mamba run -p ${{ github.workspace }}/.envs/${{ steps.get-env-hash.outputs.hash }} pip install --no-dependencies -e .
+      run: mamba run -p .envs/${{ steps.get-env-hash.outputs.hash }} pip install --no-dependencies -e .

--- a/.github/actions/create-mamba-env/action.yml
+++ b/.github/actions/create-mamba-env/action.yml
@@ -33,7 +33,7 @@ runs:
 
     - name: Get hash for environment name
       id: get-env-hash
-      run: echo "hash=${{ github.event.repository.name }}-${{ inputs.env_name }}-${{ hashFiles('requirements/base.txt', 'requirements/dev.txt') }}" >> $GITHUB_OUTPUT
+      run: echo "hash=${{ inputs.env_name }}-${{ hashFiles('requirements/base.txt', 'requirements/dev.txt') }}" >> $GITHUB_OUTPUT
 
       shell: bash
     - name: Setup Mambaforge
@@ -41,7 +41,7 @@ runs:
       with:
         miniforge-variant: Mambaforge
         miniforge-version: latest
-        activate-environment: ${{ steps.get-env-hash.outputs.hash }}
+        activate-environment: ${{ github.workspace }}/.envs/${{ steps.get-env-hash.outputs.hash }}
         use-mamba: true
         python-version: 3.${{ inputs.py3version }}
 
@@ -56,7 +56,7 @@ runs:
       uses: actions/cache@v3
       with:
         path: |
-          ${{ env.CONDA }}/envs
+          ${{ github.workspace }}/.envs
           ${{ inputs.additional_cache_dir }}
         key: ${{ steps.get-refresh-timestamp.outputs.timestamp }}-${{ steps.get-env-hash.outputs.hash }}
 
@@ -66,7 +66,7 @@ runs:
       run:
         mamba update
         -c city-modelling-lab
-        -n ${{ steps.get-env-hash.outputs.hash }}
+        -n ${{ github.workspace }}/.envs/${{ steps.get-env-hash.outputs.hash }}
         ruff
         ${{ inputs.additional_mamba_args }}
         --file requirements/base.txt
@@ -74,4 +74,4 @@ runs:
 
     - name: Install package
       shell: bash
-      run: mamba run -n ${{ steps.get-env-hash.outputs.hash }} pip install --no-dependencies -e .
+      run: mamba run -n ${{ github.workspace }}/.envs/${{ steps.get-env-hash.outputs.hash }} pip install --no-dependencies -e .

--- a/.github/actions/create-mamba-env/action.yml
+++ b/.github/actions/create-mamba-env/action.yml
@@ -66,7 +66,7 @@ runs:
       run:
         mamba update
         -c city-modelling-lab
-        -n ${{ github.workspace }}/.envs/${{ steps.get-env-hash.outputs.hash }}
+        -p ${{ github.workspace }}/.envs/${{ steps.get-env-hash.outputs.hash }}
         ruff
         ${{ inputs.additional_mamba_args }}
         --file requirements/base.txt
@@ -74,4 +74,4 @@ runs:
 
     - name: Install package
       shell: bash
-      run: mamba run -n ${{ github.workspace }}/.envs/${{ steps.get-env-hash.outputs.hash }} pip install --no-dependencies -e .
+      run: mamba run -p ${{ github.workspace }}/.envs/${{ steps.get-env-hash.outputs.hash }} pip install --no-dependencies -e .

--- a/.github/actions/create-mamba-env/action.yml
+++ b/.github/actions/create-mamba-env/action.yml
@@ -64,7 +64,8 @@ runs:
       if: steps.cache.outputs.cache-hit != 'true'
       shell: bash
       run:
-        mamba update
+        mamba create
+        --yes
         -c city-modelling-lab
         -p .envs/${{ steps.get-env-hash.outputs.hash }}
         ruff

--- a/.github/actions/create-mamba-env/action.yml
+++ b/.github/actions/create-mamba-env/action.yml
@@ -22,7 +22,6 @@ inputs:
       Format options are '%Y' (year), '%m' (month) and '%d' (day).
     required: false
     default: "+%Y%m"
-
 runs:
   using: "composite" #
   steps:
@@ -38,7 +37,7 @@ runs:
       with:
         miniforge-variant: Mambaforge
         miniforge-version: latest
-        activate-environment: .envs/${{ steps.get-env-hash.outputs.hash }}
+        activate-environment: ${{ steps.get-env-hash.outputs.hash }}
         use-mamba: true
         python-version: 3.${{ inputs.py3version }}
 
@@ -52,7 +51,9 @@ runs:
       if: ${{ inputs.cache_mamba_env }} == 'true'
       uses: actions/cache@v3
       with:
-        path: .envs
+        path: |
+          ${{ env.CONDA }}/envs
+          .cache/envs
         key: ${{ steps.get-refresh-timestamp.outputs.timestamp }}-${{ steps.get-env-hash.outputs.hash }}
 
     - name: Update environment
@@ -62,7 +63,7 @@ runs:
         mamba create
         --yes
         -c city-modelling-lab
-        -p .envs/${{ steps.get-env-hash.outputs.hash }}
+        -n ${{ steps.get-env-hash.outputs.hash }}
         ruff
         ${{ inputs.additional_mamba_args }}
         --file requirements/base.txt
@@ -70,4 +71,4 @@ runs:
 
     - name: Install package
       shell: bash
-      run: mamba run -p .envs/${{ steps.get-env-hash.outputs.hash }} pip install --no-dependencies -e .
+      run: mamba run -n ${{ steps.get-env-hash.outputs.hash }} pip install --no-dependencies -e .

--- a/.github/actions/create-mamba-env/action.yml
+++ b/.github/actions/create-mamba-env/action.yml
@@ -66,7 +66,7 @@ runs:
       run:
         mamba update
         -c city-modelling-lab
-        -p ${{ github.workspace }}/.envs/${{ steps.get-env-hash.outputs.hash }}
+        -p '${{ github.workspace }}/.envs/${{ steps.get-env-hash.outputs.hash }}'
         ruff
         ${{ inputs.additional_mamba_args }}
         --file requirements/base.txt

--- a/.github/actions/create-mamba-env/action.yml
+++ b/.github/actions/create-mamba-env/action.yml
@@ -22,10 +22,7 @@ inputs:
       Format options are '%Y' (year), '%m' (month) and '%d' (day).
     required: false
     default: "+%Y%m"
-  additional_cache_dir:
-    description: Add directory to cache, beyond the default conda/mamba environment directory
-    required: false
-    default: ""
+
 runs:
   using: "composite" #
   steps:
@@ -55,9 +52,7 @@ runs:
       if: ${{ inputs.cache_mamba_env }} == 'true'
       uses: actions/cache@v3
       with:
-        path: |
-          .envs
-          ${{ inputs.additional_cache_dir }}
+        path: .envs
         key: ${{ steps.get-refresh-timestamp.outputs.timestamp }}-${{ steps.get-env-hash.outputs.hash }}
 
     - name: Update environment

--- a/.github/actions/create-mamba-env/action.yml
+++ b/.github/actions/create-mamba-env/action.yml
@@ -22,6 +22,10 @@ inputs:
       Format options are '%Y' (year), '%m' (month) and '%d' (day).
     required: false
     default: "+%Y%m"
+  additional_cache_dir:
+    description: Add directory to cache, beyond the default conda/mamba environment directory
+    required: false
+    default: ""
 runs:
   using: "composite" #
   steps:
@@ -51,7 +55,9 @@ runs:
       if: ${{ inputs.cache_mamba_env }} == 'true'
       uses: actions/cache@v3
       with:
-        path: ${{ env.CONDA }}/envs
+        path: |
+          ${{ env.CONDA }}/envs
+          ${{ inputs.additional_cache_dir }}
         key: ${{ steps.get-refresh-timestamp.outputs.timestamp }}-${{ steps.get-env-hash.outputs.hash }}
 
     - name: Update environment

--- a/.github/workflows/docs-a11y.yml
+++ b/.github/workflows/docs-a11y.yml
@@ -34,8 +34,6 @@ jobs:
   docs-accessibility:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v4
-
     - uses: arup-group/actions-city-modelling-lab/.github/actions/create-mamba-env@main
       with:
         py3version: ${{ inputs.py3version }}

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -34,14 +34,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       id: branch-exists
       with:
         path: tmp/gh-pages
         ref: gh-pages
       continue-on-error: true
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0  # used to build docs into the gh-pages branch without losing branch history. See https://github.com/jimporter/mike/issues/49
 

--- a/.github/workflows/python-install-lint-test.yml
+++ b/.github/workflows/python-install-lint-test.yml
@@ -44,6 +44,11 @@ on:
         required: false
         default: true
         type: boolean
+      additional_cache_dir:
+        description: Add directory to cache, beyond the default conda/mamba environment directory
+        required: false
+        default: ""
+        type: string
 
 defaults:
   run:
@@ -61,25 +66,13 @@ jobs:
       if: inputs.mamba_env_name == ''
       run: echo "MAMBAENVNAME=${{ inputs.os }}-3${{ inputs.py3version }}" >> $GITHUB_ENV
 
-    - name: Set GitHub workspace to C drive on Windows
-      if: startsWith(inputs.os, 'windows')
-      run: |
-        echo "GITHUB_WORKSPACE='C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}'" >> $GITHUB_ENV
-        echo "RUNNER_WORKSPACE='C:\\a\\${{ github.event.repository.name }}'" >> $GITHUB_ENV
-
-    - name: Echo
-      run:
-        echo ${{ github.workspace }}
-        echo ${{ runner.workspace }}
-        echo ${{ env.GITHUB_WORKSPACE }}
-        echo ${{ env.RUNNER_WORKSPACE }}
-
-    - uses: arup-group/actions-city-modelling-lab/.github/actions/create-mamba-env@main
+    - uses: arup-group/actions-city-modelling-lab/.github/actions/create-mamba-env@update-windows-gh-workspace
       with:
         py3version: ${{ inputs.py3version }}
         env_name: ${{ env.MAMBAENVNAME }}
         additional_mamba_args: ${{ inputs.additional_mamba_args }}
         cache_mamba_env: "${{ inputs.cache_mamba_env }}"
+        additional_cache_dir: ${{ inputs.additional_cache_dir }}
 
     - name: Install jupyter kernel
       if: inputs.notebook_kernel != ''

--- a/.github/workflows/python-install-lint-test.yml
+++ b/.github/workflows/python-install-lint-test.yml
@@ -61,7 +61,7 @@ jobs:
       if: inputs.mamba_env_name == ''
       run: echo "MAMBAENVNAME=${{ inputs.os }}-3${{ inputs.py3version }}" >> $GITHUB_ENV
 
-    - uses: arup-group/actions-city-modelling-lab/.github/actions/create-mamba-env@update-windows-gh-workspace
+    - uses: arup-group/actions-city-modelling-lab/.github/actions/create-mamba-env@main
       with:
         py3version: ${{ inputs.py3version }}
         env_name: ${{ env.MAMBAENVNAME }}

--- a/.github/workflows/python-install-lint-test.yml
+++ b/.github/workflows/python-install-lint-test.yml
@@ -63,7 +63,10 @@ jobs:
 
     - name: Set GitHub workspace to C drive on Windows
       if: startsWith(inputs.os, 'windows')
-      run: echo "GITHUB_WORKSPACE='C:\\a\\'" >> $GITHUB_ENV
+      run: |
+        echo "GITHUB_WORKSPACE='C:\\a\\'" >> $GITHUB_ENV
+        echo ${{ github.workspace }}
+        echo ${{ env.GITHUB_WORKSPACE }}
 
     - uses: arup-group/actions-city-modelling-lab/.github/actions/create-mamba-env@main
       with:

--- a/.github/workflows/python-install-lint-test.yml
+++ b/.github/workflows/python-install-lint-test.yml
@@ -63,7 +63,7 @@ jobs:
 
     - name: Set GitHub workspace to C drive on Windows
       if: startsWith(inputs.os, 'windows')
-      run: echo "GITHUB_WORKSPACE='C:\a\'" >> $GITHUB_ENV
+      run: echo "GITHUB_WORKSPACE='C:\\a\\'" >> $GITHUB_ENV
 
     - uses: arup-group/actions-city-modelling-lab/.github/actions/create-mamba-env@main
       with:

--- a/.github/workflows/python-install-lint-test.yml
+++ b/.github/workflows/python-install-lint-test.yml
@@ -66,6 +66,7 @@ jobs:
       run: |
         echo "GITHUB_WORKSPACE='C:\\a\\'" >> $GITHUB_ENV
         echo ${{ github.workspace }}
+        echo ${{ runner.workspace }}
         echo ${{ env.GITHUB_WORKSPACE }}
 
     - uses: arup-group/actions-city-modelling-lab/.github/actions/create-mamba-env@main

--- a/.github/workflows/python-install-lint-test.yml
+++ b/.github/workflows/python-install-lint-test.yml
@@ -53,8 +53,6 @@ jobs:
   test:
     runs-on: ${{ inputs.os }}
     steps:
-    - uses: actions/checkout@v4
-
     - name: Use supplied Mamba environment name
       if: inputs.mamba_env_name != ''
       run: echo "MAMBAENVNAME=${{ inputs.mamba_env_name }}" >> $GITHUB_ENV
@@ -62,6 +60,10 @@ jobs:
     - name: Create Mamba environment name based on OS and python version
       if: inputs.mamba_env_name == ''
       run: echo "MAMBAENVNAME=${{ inputs.os }}-3${{ inputs.py3version }}" >> $GITHUB_ENV
+
+    - name: Set GitHub workspace to C drive on Windows
+      if: startsWith(inputs.os, 'windows')
+      run: echo "GITHUB_WORKSPACE=C:\a\" >> $GITHUB_ENV
 
     - uses: arup-group/actions-city-modelling-lab/.github/actions/create-mamba-env@main
       with:

--- a/.github/workflows/python-install-lint-test.yml
+++ b/.github/workflows/python-install-lint-test.yml
@@ -64,10 +64,15 @@ jobs:
     - name: Set GitHub workspace to C drive on Windows
       if: startsWith(inputs.os, 'windows')
       run: |
-        echo "GITHUB_WORKSPACE='C:\\a\\'" >> $GITHUB_ENV
+        echo "GITHUB_WORKSPACE='C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}'" >> $GITHUB_ENV
+        echo "RUNNER_WORKSPACE='C:\\a\\${{ github.event.repository.name }}'" >> $GITHUB_ENV
+
+    - name: Echo
+      run:
         echo ${{ github.workspace }}
         echo ${{ runner.workspace }}
         echo ${{ env.GITHUB_WORKSPACE }}
+        echo ${{ env.RUNNER_WORKSPACE }}
 
     - uses: arup-group/actions-city-modelling-lab/.github/actions/create-mamba-env@main
       with:

--- a/.github/workflows/python-install-lint-test.yml
+++ b/.github/workflows/python-install-lint-test.yml
@@ -63,7 +63,7 @@ jobs:
 
     - name: Set GitHub workspace to C drive on Windows
       if: startsWith(inputs.os, 'windows')
-      run: echo "GITHUB_WORKSPACE=C:\a\" >> $GITHUB_ENV
+      run: echo "GITHUB_WORKSPACE='C:\a\'" >> $GITHUB_ENV
 
     - uses: arup-group/actions-city-modelling-lab/.github/actions/create-mamba-env@main
       with:

--- a/.github/workflows/python-install-lint-test.yml
+++ b/.github/workflows/python-install-lint-test.yml
@@ -44,11 +44,6 @@ on:
         required: false
         default: true
         type: boolean
-      additional_cache_dir:
-        description: Add directory to cache, beyond the default conda/mamba environment directory
-        required: false
-        default: ""
-        type: string
 
 defaults:
   run:
@@ -72,7 +67,6 @@ jobs:
         env_name: ${{ env.MAMBAENVNAME }}
         additional_mamba_args: ${{ inputs.additional_mamba_args }}
         cache_mamba_env: "${{ inputs.cache_mamba_env }}"
-        additional_cache_dir: ${{ inputs.additional_cache_dir }}
 
     - name: Install jupyter kernel
       if: inputs.notebook_kernel != ''

--- a/.github/workflows/python-memory-profile.yml
+++ b/.github/workflows/python-memory-profile.yml
@@ -25,8 +25,6 @@ jobs:
   memory-profiler:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-
       - uses: arup-group/actions-city-modelling-lab/.github/actions/create-mamba-env@main
         with:
           py3version: ${{ inputs.py3version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Mamba environment creation composite action uses `mamba create --yes` instead of `mamba update` to catch unpinned dependencies (#28).
+
 ### Changed
 
 - Moved to `conda-incubator/setup-miniconda` instead of `mamba-org/setup-micromamba` where we would benefit from having `mamba`/`conda` available on the runner PATH (#26).
@@ -25,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Composite action for building a project-specific conda environment, used across reusable workflows but also available for direct use as a step in other projects (#26).
+- Environment cache directory within the runner working directory (`.cache/envs`) (#29).
 
 ## [v1.0.0] - 2024-07-12
 


### PR DESCRIPTION
Fixes #28 

Also adds:
1. pointer to a second environment cache directory in the working directory (`.cache/envs`) which allows us to cache environments in the same drive as the working directory (mitigating [this snakemake issue](https://github.com/snakemake/snakemake/issues/2964)). 
2. cleanup of cache hash and of use of `actions/checkout` to avoid duplication between the composite action and the calling workflows.