### PR TITLE
Do not cache full environments, only lockfiles

### DIFF
--- a/.github/actions/create-mamba-env/action.yml
+++ b/.github/actions/create-mamba-env/action.yml
@@ -51,9 +51,7 @@ runs:
       if: ${{ inputs.cache_mamba_env }} == 'true'
       uses: actions/cache@v3
       with:
-        path: |
-          ${{ env.CONDA }}/envs
-          .cache/envs
+        path: ${{ env.CONDA }}/envs
         key: ${{ steps.get-refresh-timestamp.outputs.timestamp }}-${{ steps.get-env-hash.outputs.hash }}
 
     - name: Update environment

--- a/.github/actions/create-mamba-env/action.yml
+++ b/.github/actions/create-mamba-env/action.yml
@@ -22,24 +22,23 @@ inputs:
       Format options are '%Y' (year), '%m' (month) and '%d' (day).
     required: false
     default: "+%Y%m"
+
 runs:
-  using: "composite" #
+  using: "composite"
   steps:
     - uses: actions/checkout@v4
 
     - name: Get hash for environment name
       id: get-env-hash
-      run: echo "hash=${{ inputs.env_name }}-${{ hashFiles('requirements/base.txt', 'requirements/dev.txt') }}" >> $GITHUB_OUTPUT
-
+      run: echo "hash=${{ inputs.env_name }}-${{ hashFiles('requirements/**.txt') }}" >> $GITHUB_OUTPUT
       shell: bash
-    - name: Setup Mambaforge
-      uses: conda-incubator/setup-miniconda@v3
-      with:
-        miniforge-variant: Mambaforge
-        miniforge-version: latest
-        activate-environment: ${{ steps.get-env-hash.outputs.hash }}
-        use-mamba: true
-        python-version: 3.${{ inputs.py3version }}
+
+
+    - name: Exclude Mamba environment directories from Windows Defender scanning
+      id: exclude-envs-windows-defender
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: Add-MpPreference -ExclusionPath "${{ env.CONDA }}/envs,.cache/envs"
 
     - name: Get Date
       id: get-refresh-timestamp
@@ -48,15 +47,25 @@ runs:
 
     - name: Cache Mamba env
       id: cache
-      if: ${{ inputs.cache_mamba_env }} == 'true'
+      if: inputs.cache_mamba_env == 'true'
       uses: actions/cache@v3
       with:
-        path: ${{ env.CONDA }}/envs
+        path: conda-env.lock
         key: ${{ steps.get-refresh-timestamp.outputs.timestamp }}-${{ steps.get-env-hash.outputs.hash }}
 
-    - name: Update environment
+    - name: Set up Mambaforge with empty environment
       if: steps.cache.outputs.cache-hit != 'true'
-      shell: bash
+      uses: conda-incubator/setup-miniconda@v3
+      with:
+        miniforge-variant: Mambaforge
+        miniforge-version: latest
+        activate-environment: ${{ steps.get-env-hash.outputs.hash }}
+        use-mamba: true
+        python-version: 3.${{ inputs.py3version }}
+
+    - name: Install dependencies into empty environment
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash -l {0}
       run:
         mamba create
         --yes
@@ -67,6 +76,21 @@ runs:
         --file requirements/base.txt
         --file requirements/dev.txt
 
+    - name: Set up Mambaforge with lockfile
+      if: steps.cache.outputs.cache-hit == 'true'
+      uses: conda-incubator/setup-miniconda@v3
+      with:
+        miniforge-variant: Mambaforge
+        miniforge-version: latest
+        activate-environment: ${{ steps.get-env-hash.outputs.hash }}
+        environment-file: conda-env.lock
+        use-mamba: true
+
     - name: Install package
-      shell: bash
-      run: mamba run -n ${{ steps.get-env-hash.outputs.hash }} pip install --no-dependencies -e .
+      shell: bash -l {0}
+      run: pip install --no-dependencies -e .
+
+    - name: Create lockfile
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: mamba list --explicit > conda-env.lock
+      shell: bash -l {0}

--- a/.github/actions/create-mamba-env/action.yml
+++ b/.github/actions/create-mamba-env/action.yml
@@ -33,13 +33,6 @@ runs:
       run: echo "hash=${{ inputs.env_name }}-${{ hashFiles('requirements/**.txt') }}" >> $GITHUB_OUTPUT
       shell: bash
 
-
-    - name: Exclude Mamba environment directories from Windows Defender scanning
-      id: exclude-envs-windows-defender
-      if: runner.os == 'Windows'
-      shell: pwsh
-      run: Add-MpPreference -ExclusionPath "${{ env.CONDA }}/envs,.cache/envs"
-
     - name: Get Date
       id: get-refresh-timestamp
       run: echo "timestamp=$(/bin/date -u ${{ inputs.cache_refresh_time_format }})" >> $GITHUB_OUTPUT

--- a/.github/workflows/python-install-lint-test.yml
+++ b/.github/workflows/python-install-lint-test.yml
@@ -61,7 +61,7 @@ jobs:
       if: inputs.mamba_env_name == ''
       run: echo "MAMBAENVNAME=${{ inputs.os }}-3${{ inputs.py3version }}" >> $GITHUB_ENV
 
-    - uses: arup-group/actions-city-modelling-lab/.github/actions/create-mamba-env@no-custom-cache-dir
+    - uses: arup-group/actions-city-modelling-lab/.github/actions/create-mamba-env@main
       with:
         py3version: ${{ inputs.py3version }}
         env_name: ${{ env.MAMBAENVNAME }}

--- a/.github/workflows/python-install-lint-test.yml
+++ b/.github/workflows/python-install-lint-test.yml
@@ -61,7 +61,7 @@ jobs:
       if: inputs.mamba_env_name == ''
       run: echo "MAMBAENVNAME=${{ inputs.os }}-3${{ inputs.py3version }}" >> $GITHUB_ENV
 
-    - uses: arup-group/actions-city-modelling-lab/.github/actions/create-mamba-env@main
+    - uses: arup-group/actions-city-modelling-lab/.github/actions/create-mamba-env@no-custom-cache-dir
       with:
         py3version: ${{ inputs.py3version }}
         env_name: ${{ env.MAMBAENVNAME }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Updated environment caching method to only cache environment lockfiles / `explicit` lists, if using `conda-incubator/setup-miniconda`, to reduce Windows runner build times at the expense of slower Linux/OSX build times (#30).
 - Moved to `conda-incubator/setup-miniconda` instead of `mamba-org/setup-micromamba` where we would benefit from having `mamba`/`conda` available on the runner PATH (#26).
 
 ### Added


### PR DESCRIPTION
I've gone back and forth on this a bit, but the issue of unpacking cached environments on windows (#30) is difficult to solve. I've opted for a much simpler caching approach, whereby only a "lockfile"/explicit list of dependencies is cached. This reduces the environment creation time by removing the need for conda to resolve dependencies (since they are all explicitly linked). 

It slows things down slightly on linux/MacOS runners, compared to using a fully stored cache, but seems to improve things on Windows. SInce Windows CI runs are our rate limiter, it seems to be an OK compromise.

The other reason to switch to this approach is that it keeps our caches small (~2kb). Caching full environments is more like 200-500mb and that can quickly lead to us reaching our cache limit on repos (10GB) since we get different caches per branch, per OS, per python version, etc.