### PR TITLE
Fix pa11y CI

### DIFF
--- a/.github/workflows/docs-a11y.yml
+++ b/.github/workflows/docs-a11y.yml
@@ -53,7 +53,7 @@ jobs:
         node-version: 16
 
     - name: Install Pa11y
-      run: npm install pa11y-ci pa11y-ci-reporter-html -g
+      run: npm install pa11y-ci pa11y-ci-reporter-html -g && npm list -g --depth=0
 
     - name: Run Pa11y and pipe all output to file
       id: run-pa11y

--- a/.github/workflows/docs-a11y.yml
+++ b/.github/workflows/docs-a11y.yml
@@ -50,7 +50,7 @@ jobs:
 
     - uses: actions/setup-node@v4
       with:
-        node-version: 16
+        node-version: 20
 
     - name: Install Pa11y
       run: npm install pa11y-ci pa11y-ci-reporter-html -g && npm list -g --depth=2

--- a/.github/workflows/docs-a11y.yml
+++ b/.github/workflows/docs-a11y.yml
@@ -53,7 +53,7 @@ jobs:
         node-version: 16
 
     - name: Install Pa11y
-      run: npm install pa11y-ci pa11y-ci-reporter-html -g && npm list -g --depth=0
+      run: npm install pa11y-ci pa11y-ci-reporter-html -g && npm list -g --depth=2
 
     - name: Run Pa11y and pipe all output to file
       id: run-pa11y

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Mamba environment creation composite action uses `mamba create --yes` instead of `mamba update` to catch unpinned dependencies (#28).
+- Pa11y CI failing due to old Node.js version. Fixed by updating from v16 to v20.
 
 ### Changed
 


### PR DESCRIPTION
Accessibility tests are failing in repositories using the reusable Pa11y workflow. I've fixed it by trial and error, updating the the most recent version of Node.js available on `ubuntu-20.04` runners. I've left in the listing of globally installed node modules in the workflow as it might prove useful in future troubleshooting (in this instance, it was only useful in telling me that all the modules were the same version as I have installed locally, which then led me to try a newer version of Node.js in the workflow)