### PR TITLE
Fix pip build environment creation

### DIFF
--- a/.github/workflows/pip-build-environment.yml
+++ b/.github/workflows/pip-build-environment.yml
@@ -1,0 +1,8 @@
+name: pipbuild
+channels:
+  - conda-forge
+dependencies:
+  - python=3.11
+  - pip
+  - pip:
+    - build

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -52,11 +52,7 @@ jobs:
     - uses: mamba-org/setup-micromamba@v1
       with:
         micromamba-version: latest
-        environment-name: pipbuild
-        create-args: >-
-          python=3.11
-          pip
-          build
+        environment-file: .github/workflows/pip-build-environment.yml
         post-cleanup: all
         cache-environment: true
 
@@ -78,11 +74,7 @@ jobs:
     - uses: mamba-org/setup-micromamba@v1
       with:
         micromamba-version: latest
-        environment-name: pipbuild
-        create-args: >-
-          python=3.11
-          pip
-          build
+        environment-file: .github/workflows/pip-build-environment.yml
         post-cleanup: all
         cache-environment: true
 
@@ -105,11 +97,7 @@ jobs:
     - uses: mamba-org/setup-micromamba@v1
       with:
         micromamba-version: latest
-        environment-name: pipbuild
-        create-args: >-
-          python=3.11
-          pip
-          build
+        environment-file: .github/workflows/pip-build-environment.yml
         post-cleanup: all
         cache-environment: true
 


### PR DESCRIPTION
`build` isn't installable from conda-forge (any more), so it's installed via pip/PyPI instead