### PR TITLE
Replace deprecated mambaforge with miniforge in conda setup action usage

### DIFF
--- a/.github/actions/create-mamba-env/action.yml
+++ b/.github/actions/create-mamba-env/action.yml
@@ -46,11 +46,10 @@ runs:
         path: conda-env.lock
         key: ${{ steps.get-refresh-timestamp.outputs.timestamp }}-${{ steps.get-env-hash.outputs.hash }}
 
-    - name: Set up Mambaforge with empty environment
+    - name: Set up Miniforge with empty environment
       if: steps.cache.outputs.cache-hit != 'true'
       uses: conda-incubator/setup-miniconda@v3
       with:
-        miniforge-variant: Mambaforge
         miniforge-version: latest
         activate-environment: ${{ steps.get-env-hash.outputs.hash }}
         use-mamba: true
@@ -69,11 +68,10 @@ runs:
         --file requirements/base.txt
         --file requirements/dev.txt
 
-    - name: Set up Mambaforge with lockfile
+    - name: Set up Miniforge with lockfile
       if: steps.cache.outputs.cache-hit == 'true'
       uses: conda-incubator/setup-miniconda@v3
       with:
-        miniforge-variant: Mambaforge
         miniforge-version: latest
         activate-environment: ${{ steps.get-env-hash.outputs.hash }}
         environment-file: conda-env.lock

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -45,7 +45,7 @@ jobs:
       with:
         fetch-depth: 0  # used to build docs into the gh-pages branch without losing branch history. See https://github.com/jimporter/mike/issues/49
 
-    - uses: arup-group/actions-city-modelling-lab/.github/actions/create-mamba-env@main
+    - uses: arup-group/actions-city-modelling-lab/.github/actions/create-mamba-env@8ac47f44bae77be38a9c5b281a640ff88515b8a6
       with:
         py3version: ${{ inputs.py3version }}
         env_name: docs

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -45,7 +45,7 @@ jobs:
       with:
         fetch-depth: 0  # used to build docs into the gh-pages branch without losing branch history. See https://github.com/jimporter/mike/issues/49
 
-    - uses: arup-group/actions-city-modelling-lab/.github/actions/create-mamba-env@8ac47f44bae77be38a9c5b281a640ff88515b8a6
+    - uses: arup-group/actions-city-modelling-lab/.github/actions/create-mamba-env@main
       with:
         py3version: ${{ inputs.py3version }}
         env_name: docs

--- a/.github/workflows/python-install-lint-test.yml
+++ b/.github/workflows/python-install-lint-test.yml
@@ -61,7 +61,7 @@ jobs:
       if: inputs.mamba_env_name == ''
       run: echo "MAMBAENVNAME=${{ inputs.os }}-3${{ inputs.py3version }}" >> $GITHUB_ENV
 
-    - uses: arup-group/actions-city-modelling-lab/.github/actions/create-mamba-env@main
+    - uses: arup-group/actions-city-modelling-lab/.github/actions/create-mamba-env@8ac47f44bae77be38a9c5b281a640ff88515b8a6
       with:
         py3version: ${{ inputs.py3version }}
         env_name: ${{ env.MAMBAENVNAME }}

--- a/.github/workflows/python-install-lint-test.yml
+++ b/.github/workflows/python-install-lint-test.yml
@@ -61,7 +61,7 @@ jobs:
       if: inputs.mamba_env_name == ''
       run: echo "MAMBAENVNAME=${{ inputs.os }}-3${{ inputs.py3version }}" >> $GITHUB_ENV
 
-    - uses: arup-group/actions-city-modelling-lab/.github/actions/create-mamba-env@8ac47f44bae77be38a9c5b281a640ff88515b8a6
+    - uses: arup-group/actions-city-modelling-lab/.github/actions/create-mamba-env@main
       with:
         py3version: ${{ inputs.py3version }}
         env_name: ${{ env.MAMBAENVNAME }}


### PR DESCRIPTION
- Fixes #48

## Testing the Fix

It's quite fiddly to test this.

The dependency chain for repo CI builds looks like this:

```
- Repo CI workflows
    - CML Reusable actions, e.g. python-install-lint-test.yml
        - CML create-mamba-env/action.yml
            - conda-incubator/setup-miniconda action causing brownouts
```

I needed to commit the attempted fix to the base-level action `.github/actions/create-mamba-env/action.yml` in my branch, then pin to that version of the action in one of the reusable actions; I chose  [`.github/workflows/python-install-lint-test.yml`](https://github.com/arup-group/actions-city-modelling-lab/commit/44a5cb6dcd937c68aa297ad73904ef892fe5d863).

I then had to pin to the version of _that_ action in a CI workflow somewhere; I chose to use the [basildon_local_plan](https://github.com/arup-group/basildon_local_plan/commit/074b824ec0eec3381c79f3f050196218d224f7a5) repo, where the previously broken CI build [succeeded](https://github.com/arup-group/basildon_local_plan/actions/runs/11128076811/job/30921947695).

**Before**
<img width="1668" alt="Screenshot 2024-10-01 at 16 52 05" src="https://github.com/user-attachments/assets/1fc71fd8-9be9-4bfc-a594-6008213d656f">


**After**
<img width="1684" alt="Screenshot 2024-10-01 at 16 50 54" src="https://github.com/user-attachments/assets/f2190dd4-b4b5-4706-9f96-5c18859c07af">


Having seen that build succeed, I then backed out the change that pinned to the specific commit in `.github/workflows/python-install-lint-test.yml`. Phew. I will also discard the branch of the `basildon_local_plan` where I pinned the python lint & test action.

Once _this_ change is merged, everything that currently depends on `main` versions of the various reusable actions that depend on the `main` version of `create-mamba-env/action.yml` **should** be working again 🤞 .