### PR TITLE
Pin micromamba <v2; update cache action

### DIFF
--- a/.github/actions/create-mamba-env/action.yml
+++ b/.github/actions/create-mamba-env/action.yml
@@ -41,7 +41,7 @@ runs:
     - name: Cache Mamba env
       id: cache
       if: inputs.cache_mamba_env == 'true'
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: conda-env.lock
         key: ${{ steps.get-refresh-timestamp.outputs.timestamp }}-${{ steps.get-env-hash.outputs.hash }}

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -71,7 +71,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: mamba-org/setup-micromamba@v1
       with:
-        micromamba-version: latest
+        micromamba-version: '1.5.10-0'
         environment-name: condabuild
         create-args: >-
           python=3.11

--- a/.github/workflows/conda-upload.yml
+++ b/.github/workflows/conda-upload.yml
@@ -37,7 +37,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: mamba-org/setup-micromamba@v1
       with:
-        micromamba-version: latest
+        micromamba-version: '1.5.10-0'
         environment-name: condaupload
         create-args: >-
             python=3.11

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -51,7 +51,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: mamba-org/setup-micromamba@v1
       with:
-        micromamba-version: latest
+        micromamba-version: '1.5.10-0'
         environment-name: pipbuild
         create-args: >-
           python=3.11
@@ -77,7 +77,7 @@ jobs:
     steps:
     - uses: mamba-org/setup-micromamba@v1
       with:
-        micromamba-version: latest
+        micromamba-version: '1.5.10-0'
         environment-name: pipinstall
         create-args: >-
           python=3.11
@@ -103,7 +103,7 @@ jobs:
     steps:
     - uses: mamba-org/setup-micromamba@v1
       with:
-        micromamba-version: latest
+        micromamba-version: '1.5.10-0'
         environment-name: pipinstall
         create-args: >-
           python=3.11

--- a/.github/workflows/template-check.yml
+++ b/.github/workflows/template-check.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: mamba-org/setup-micromamba@v1
         with:
-          micromamba-version: latest
+          micromamba-version: '1.5.10-0'
           environment-name: ${{ github.event.repository.name }}-cruft
           create-args: cruft python=3.11
           post-cleanup: all


### PR DESCRIPTION
Fixes #47 

Clearly [some more ironing out required before micromamba v2 is fit for purpose](https://github.com/mamba-org/setup-micromamba/issues/227). This pins to most recent v1. We can update to v2 when they're a few minor releases in.

While I'm here, I'm updating to actions/cache@v4. I've checked the [changelog](https://github.com/actions/cache/blob/main/RELEASES.md) and there's nothing to be concerned about. This should remove the following deprecation warning:

![Screenshot 2024-10-03 at 10 30 51](https://github.com/user-attachments/assets/234c08f7-f8dc-4e57-8907-cbc98f3e86a2)
