### PR TITLE
Sanitise repo names used as zip file names in AWS uploads

### DIFF
--- a/.github/workflows/aws-upload.yml
+++ b/.github/workflows/aws-upload.yml
@@ -46,4 +46,6 @@ jobs:
         echo ${{ github.sha }} > release
         zip -r app.zip .
     - name: Push zip to S3
-      run: aws s3 cp app.zip "s3://${{ secrets.AWS_S3_CODE_BUCKET }}/${{ github.event.repository.name }}.zip"
+      run: |
+        sanitised_repo_name=$(echo ${{ github.event.repository.name }} | tr '[:upper:]' '[:lower:]')
+        aws s3 cp app.zip "s3://${{ secrets.AWS_S3_CODE_BUCKET }}/$sanitised_repo_name.zip"


### PR DESCRIPTION
- Closes #57 

@D-Dulius and @Dominic-Duke: I've added you both as reviewers because you've recently expressed an interest in learning more about GitHub actions and workflows. Don't feel the need to formally review the PR unless you want to.

## Verification

I used the version of the AWS upload action from this branch in [a branch of BitSim that I am working on](https://github.com/arup-group/BitSim/commit/6a60993c89320bc68961a3dc15cb6bf2c9ea7e14) to replace inline code in the CI build with our reusable actions.

I confirmed that the zip file uploaded to S3 from the CI build on that branch now uses a lowercase name and that it now triggers the downstream AWS CD pipeline as a result:

```shell
aws s3 ls s3://<code-bucket-name-elided>/ | grep -i bitsim | sort -r

2024-11-26 16:14:34     851080 bitsim.zip # zip file uploaded by the branch version of the S3 upload action
2024-11-26 16:05:35     851163 BitSim.zip # zip file uploaded by the current main version of the S3 upload action
```

## Alternative Approaches

It's somewhat opaque to transform the repo name inside this action. I can't think of an obvious problem with that for our typical use cases, but perhaps some use cases will require the repo name to remain in its original format for some reason.

Another approach would be to add an optional param to the action to override the repo/zip file name if present and default to the current behaviour where no param is supplied. It would then be up to workflow calling the action to transform the repo name as appropriate before asking for the repo to be uploaded to S3.

That would be cleaner in some ways, but it's slightly more work and might be overkill. Let me know what you think.
