### PR TITLE
Add optional zip file name param to aws upload

### DIFF
--- a/.github/workflows/aws-upload.yml
+++ b/.github/workflows/aws-upload.yml
@@ -58,6 +58,7 @@ jobs:
       run: |
         zip_file_name=${{ inputs.zip-file-name-root }}
         if [ "$zip_file_name" = "repo-name" ]; then
-          $zip_file_name="${{ github.event.repository.name }}"
+          echo "Using the default name for the zip file"
+          zip_file_name="${{ github.event.repository.name }}"
         fi
         aws s3 cp app.zip "s3://${{ secrets.AWS_S3_CODE_BUCKET }}/$zip_file_name.zip"

--- a/.github/workflows/aws-upload.yml
+++ b/.github/workflows/aws-upload.yml
@@ -58,6 +58,6 @@ jobs:
       run: |
         zip_file_name=${{ inputs.zip-file-name-root }}
         if [ "$zip_file_name" = "repo-name" ]; then
-          $zip_file_name=${{ github.event.repository.name }}
+          $zip_file_name="${{ github.event.repository.name }}"
         fi
         aws s3 cp app.zip "s3://${{ secrets.AWS_S3_CODE_BUCKET }}/$zip_file_name.zip"

--- a/.github/workflows/aws-upload.yml
+++ b/.github/workflows/aws-upload.yml
@@ -18,6 +18,15 @@ on:
         required: false
         type: string
         default: 'no-tags'
+      zip-file-name-root:
+        description: >
+          An optional value to use as the name of the zip file
+          uploaded to AWS S3. For example, the value myLovelyRepo
+          results in myLovelyRepo.zip being uploaded to S3. Where
+          no value is passed, the zip file will be <exact-repo-name>.zip
+        required: false
+        type: string
+        default: 'repo-name'
 
 jobs:
   upload-to-aws:
@@ -46,4 +55,9 @@ jobs:
         echo ${{ github.sha }} > release
         zip -r app.zip .
     - name: Push zip to S3
-      run: aws s3 cp app.zip "s3://${{ secrets.AWS_S3_CODE_BUCKET }}/${{ github.event.repository.name }}.zip"
+      run: |
+        zip_file_name = ${{ inputs.zip-file-name-root }}
+        if [ "$zip_file_name" = "repo-name" ]; then
+          zip_file_name = ${{ github.event.repository.name }}
+        fi
+        aws s3 cp app.zip "s3://${{ secrets.AWS_S3_CODE_BUCKET }}/$zip_file_name.zip"

--- a/.github/workflows/aws-upload.yml
+++ b/.github/workflows/aws-upload.yml
@@ -56,8 +56,8 @@ jobs:
         zip -r app.zip .
     - name: Push zip to S3
       run: |
-        zip_file_name = ${{ inputs.zip-file-name-root }}
+        zip_file_name=${{ inputs.zip-file-name-root }}
         if [ "$zip_file_name" = "repo-name" ]; then
-          zip_file_name = ${{ github.event.repository.name }}
+          $zip_file_name=${{ github.event.repository.name }}
         fi
         aws s3 cp app.zip "s3://${{ secrets.AWS_S3_CODE_BUCKET }}/$zip_file_name.zip"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,11 +29,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated environment caching method to only cache environment lockfiles / `explicit` lists, if using `conda-incubator/setup-miniconda`, to reduce Windows runner build times at the expense of slower Linux/OSX build times (#30).
 - Moved to `conda-incubator/setup-miniconda` instead of `mamba-org/setup-micromamba` where we would benefit from having `mamba`/`conda` available on the runner PATH (#26).
+- Added an optional zip file name parameter to `aws-upload/yml` (#57).
 
 ### Added
 
 - Composite action for building a project-specific conda environment, used across reusable workflows but also available for direct use as a step in other projects (#26).
 - Environment cache directory within the runner working directory (`.cache/envs`) (#29).
+
 
 ## [v1.0.0] - 2024-07-12
 


### PR DESCRIPTION
- Closes #57 

@D-Dulius and @Dominic-Duke, I've added you both to this PR because you recently expressed an interest in learning about GitHub Actions. You don't need to actually review the PR (unless you want to).

## Verification

I have a branch of BitSim where I am replacing inlined actions like sending slack notifications and uploading the repo to S3 with the corresponding workflows in this repo. I used this version of the AWS Upload workflow (`arup-group/actions-city-modelling-lab/.github/workflows/aws-upload.yml@b13b453ab1ef4f48e1e34be8fcdf97a47a45cb3d`) in that branch. 

### Overriding the default zip file name

#### BitSim workflow config

<img width="1079" alt="Screenshot 2024-11-27 at 16 49 46" src="https://github.com/user-attachments/assets/3fe11fb6-3271-4dfd-987f-3f2b3524c507">

#### The log output in Actions

<img width="884" alt="Screenshot 2024-11-27 at 16 51 58" src="https://github.com/user-attachments/assets/22dff5dd-6709-4599-9428-dc5fdf80cbb7">

#### The zip file in S3

```shell
aws s3 ls s3://<code-bucket>/ | grep -i lovely

2024-11-27 16:51:17     851103 MyLovelyRepo.zip
```

### Using the default zip file name

#### BitSim workflow config

<img width="1076" alt="Screenshot 2024-11-27 at 16 46 05" src="https://github.com/user-attachments/assets/872a926c-11b0-419d-a58e-062b047d0584">

#### The log output in Actions

<img width="907" alt="Screenshot 2024-11-27 at 16 45 52" src="https://github.com/user-attachments/assets/5294e6d5-bc12-4866-adba-13b0951e68de">

#### The zip file in S3

```shell
aws s3 ls s3://<code-bucket>/ | grep -i "bitsim.zip"

2024-11-27 16:45:02     851068 BitSim.zip
2024-11-26 16:14:34     851080 bitsim.zip
```
