### PR TITLE
Loosen memray pinning

### DIFF
--- a/.github/workflows/python-memory-profile.yml
+++ b/.github/workflows/python-memory-profile.yml
@@ -30,8 +30,8 @@ jobs:
           py3version: ${{ inputs.py3version }}
           env_name: profiling
           additional_mamba_args:
-            memray=1.9
-            pytest-memray=1.5
+            memray=1
+            pytest-memray=1
             ${{ inputs.additional_mamba_args }}
           cache_mamba_env: "true"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Loosened `memray` dependency pinning in `python-memory-profile.yml` to ensure version compatibility with a wider range of project pinning.
 - Updated environment caching method to only cache environment lockfiles / `explicit` lists, if using `conda-incubator/setup-miniconda`, to reduce Windows runner build times at the expense of slower Linux/OSX build times (#30).
 - Moved to `conda-incubator/setup-miniconda` instead of `mamba-org/setup-micromamba` where we would benefit from having `mamba`/`conda` available on the runner PATH (#26).
 - Added an optional zip file name parameter to `aws-upload/yml` (#57).


### PR DESCRIPTION
As seen on a recent project, strict memray version pinning can cause problems with environment creation (since the memray deps need to be installed alongside all the project deps). I've loosened it to point to the major version only. Hopefully, if they are following best practice, this should mean we are not affected by breaking changes!