### PR TITLE
Update changelog for release

### DIFF
--- a/.github/workflows/docs-a11y.yml
+++ b/.github/workflows/docs-a11y.yml
@@ -34,7 +34,7 @@ jobs:
   docs-accessibility:
     runs-on: ubuntu-20.04
     steps:
-    - uses: arup-group/actions-city-modelling-lab/.github/actions/create-conda-env@update-setup-miniconda
+    - uses: arup-group/actions-city-modelling-lab/.github/actions/create-conda-env@v1.1.0
       with:
         py3version: ${{ inputs.py3version }}
         env_name: docs

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -45,7 +45,7 @@ jobs:
       with:
         fetch-depth: 0  # used to build docs into the gh-pages branch without losing branch history. See https://github.com/jimporter/mike/issues/49
 
-    - uses: arup-group/actions-city-modelling-lab/.github/actions/create-conda-env@update-setup-miniconda
+    - uses: arup-group/actions-city-modelling-lab/.github/actions/create-conda-env@v1.1.0
       with:
         py3version: ${{ inputs.py3version }}
         env_name: docs

--- a/.github/workflows/python-install-lint-test.yml
+++ b/.github/workflows/python-install-lint-test.yml
@@ -61,7 +61,7 @@ jobs:
       if: inputs.env_name == ''
       run: echo "ENVNAME=${{ inputs.os }}-3${{ inputs.py3version }}" >> $GITHUB_ENV
 
-    - uses: arup-group/actions-city-modelling-lab/.github/actions/create-conda-env@update-setup-miniconda
+    - uses: arup-group/actions-city-modelling-lab/.github/actions/create-conda-env@v1.1.0
       with:
         py3version: ${{ inputs.py3version }}
         env_name: ${{ env.ENVNAME }}

--- a/.github/workflows/python-memory-profile.yml
+++ b/.github/workflows/python-memory-profile.yml
@@ -25,7 +25,7 @@ jobs:
   memory-profiler:
     runs-on: ubuntu-latest
     steps:
-      - uses: arup-group/actions-city-modelling-lab/.github/actions/create-conda-env@update-setup-miniconda
+      - uses: arup-group/actions-city-modelling-lab/.github/actions/create-conda-env@v1.1.0
         with:
           py3version: ${{ inputs.py3version }}
           env_name: profiling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v1.1.0] - 2025-03-26
 
 ### Fixed
 


### PR DESCRIPTION
Releasing the current version and then I will pin the cookiecutter template against this release. That way, we can make changes to work with the Copier template in later releases without affecting projects that still rely on the cookiecutter template.