### PR TITLE
Add bioconda to channels list in conda config

### DIFF
--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -84,8 +84,8 @@ jobs:
         post-cleanup: all
         cache-environment: true
 
-    - name: Add conda channel
-      run: conda config --add channels city-modelling-lab
+    - name: Add useful conda channels
+      run: conda config --add channels city-modelling-lab --add channels bioconda
 
     - name: Build conda package
       run: conda mambabuild ${{ inputs.recipe_dir }}


### PR DESCRIPTION
Any time we have snakemake we need the bioconda channel, which is then needed when building a conda package. 

A more robust approach would be to make the channel list configurable by the user, but this is a quick alternative!