### PR TITLE
Update to copier template check

### DIFF
--- a/.github/workflows/template-check.yml
+++ b/.github/workflows/template-check.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       UPDATE: "false"
-      CONFLICTS: "No conflicts, merging in these changes should be a piece of cake 🍰!"
+      CONFLICTS: ""
     steps:
         - uses: actions/checkout@v4
 
@@ -47,6 +47,10 @@ jobs:
               echo 'CONFLICTS<<EOF'
               echo EOF
             } >> "$GITHUB_ENV"
+
+        - if: env.UPDATE != 'true'
+          run: |
+            echo CONFLICTS=No conflicts, merging in these changes should be a piece of cake 🍰! >> $GITHUB_ENV
 
         - if: env.UPDATE == 'true'
           name: Get commit compare URL

--- a/.github/workflows/template-check.yml
+++ b/.github/workflows/template-check.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       UPDATE: "false"
-      CONFLICTS: ""
+      CONFLICTS: "No conflicts, merging in these changes should be a piece of cake 🍰!"
     steps:
         - uses: actions/checkout@v4
 
@@ -26,8 +26,8 @@ jobs:
         - name: Get current Copier commit to compare against
           run: |
             COMMIT=$(grep "_commit:" .copier-answers.yml | cut -f2 -d' ')
-            SRC=$(grep "_src_path:" .copier-answers.yml | cut -f2 -d' ' | cut -f1 -f2 -d'.')
-            echo "COMPARE=${SRC}/compare/${SRC}" >> $GITHUB_ENV
+            SRC=$(grep "_src_path:" .copier-answers.yml | cut -f2 -d' ')
+            echo "COMPARE_PREFIX=${SRC}/compare/${COMMIT}" >> $GITHUB_ENV
 
         - name: Add dummy GitHub credentials
           run: |
@@ -52,7 +52,7 @@ jobs:
           name: Get commit compare URL
           run: |
             COMMIT=$(grep "_commit:" .copier-answers.yml | cut -f2 -d' ')
-            echo "COMPARE=${{ env.COMPARE }}...${COMMIT}" >> $GITHUB_ENV
+            echo "COMPARE=${{ env.COMPARE_PREFIX }}...${COMMIT}" >> $GITHUB_ENV
 
         - name: Comment on PR with request to update against template.
           if: env.UPDATE == 'true'
@@ -60,7 +60,7 @@ jobs:
           with:
             message: |
               >[!CAUTION]
-              >🤖 <beep boop> 🤖
+              >🤖 **beep boop** 🤖
               >This is the template updater bot.
               >Your project is out of date relative to the upstream template.
               >

--- a/.github/workflows/template-check.yml
+++ b/.github/workflows/template-check.yml
@@ -27,7 +27,7 @@ jobs:
           run: |
             COMMIT=$(grep "_commit:" .copier-answers.yml | cut -f2 -d' ')
             SRC=$(grep "_src_path:" .copier-answers.yml | cut -f2 -d' ')
-            echo "COMPARE_PREFIX=${SRC}/compare/${COMMIT}" >> $GITHUB_ENV
+            echo "COMPARE_PREFIX=${SRC%.*}/compare/${COMMIT}" >> $GITHUB_ENV
 
         - name: Add dummy GitHub credentials
           run: |

--- a/.github/workflows/template-check.yml
+++ b/.github/workflows/template-check.yml
@@ -80,3 +80,11 @@ jobs:
 
             pr-number: ${{ github.event.number }}
             comment-tag: execution
+
+
+        - name: Delete a comment
+          if: env.UPDATE != 'true'
+          uses: thollander/actions-comment-pull-request@v3
+          with:
+            comment-tag: execution
+            mode: delete

--- a/.github/workflows/template-check.yml
+++ b/.github/workflows/template-check.yml
@@ -7,23 +7,72 @@ defaults:
     shell: bash -l {0}
 
 jobs:
-  cruft-check:
+  copier-update:
     runs-on: ubuntu-latest
+    env:
+      UPDATE: "false"
+      CONFLICTS: ""
     steps:
-      - uses: actions/checkout@v4
-      - uses: mamba-org/setup-micromamba@v2
-        with:
-          micromamba-version: '1.5.10-0'
-          environment-name: ${{ github.event.repository.name }}-cruft
-          create-args: cruft python=3.11
-          post-cleanup: all
-          cache-environment: true
+        - uses: actions/checkout@v4
 
-      - name: Add dummy GitHub credentials
-        run: |
-          git config --global user.name Cruft check
-          git config --global user.email check@dummy.bot.com
+        - uses: mamba-org/setup-micromamba@v2
+          with:
+            micromamba-version: '1.5.10-0'
+            environment-name: ${{ github.event.repository.name }}-copier
+            create-args: copier python=3.12
+            post-cleanup: all
+            cache-environment: true
 
-      - name: Check project against template
-        id: check
-        run: cruft check
+        - name: Get current Copier commit to compare against
+          run: |
+            COMMIT=$(grep "_commit:" .copier-answers.yml | cut -f2 -d' ')
+            SRC=$(grep "_src_path:" .copier-answers.yml | cut -f2 -d' ' | cut -f1 -f2 -d'.')
+            echo "COMPARE=${SRC}/compare/${SRC}" >> $GITHUB_ENV
+
+        - name: Add dummy GitHub credentials
+          run: |
+            git config --global user.name Copier update
+            git config --global user.email check@dummy.bot.com
+
+        - run: copier update -A -f
+
+        - id: requires-update
+          run: test -z "$(git status --porcelain)" || echo "UPDATE=true" >> $GITHUB_ENV
+
+        - if: env.UPDATE == 'true'
+          name: Find merge conflicts
+          run: |
+            {
+              CONFLICTS=$(git diff --name-only --diff-filter=U --relative)
+              echo 'CONFLICTS<<EOF'
+              echo EOF
+            } >> "$GITHUB_ENV"
+
+        - if: env.UPDATE == 'true'
+          name: Get commit compare URL
+          run: |
+            COMMIT=$(grep "_commit:" .copier-answers.yml | cut -f2 -d' ')
+            echo "COMPARE=${{ env.COMPARE }}...${COMMIT}" >> $GITHUB_ENV
+
+        - name: Comment on PR with request to update against template.
+          if: env.UPDATE == 'true'
+          uses: thollander/actions-comment-pull-request@v3
+          with:
+            message: |
+              >[!CAUTION]
+              >🤖 <beep boop> 🤖
+              >This is the template updater bot.
+              >Your project is out of date relative to the upstream template.
+              >
+              >Please run `copier update --skip-answered` and create a new PR with those changes.
+              >
+              >You can compare the template changes here: <${{ env.COMPARE }}>
+
+              <details><summary>Click to view possible conflicts</summary>
+
+              ${{ env.CONFLICTS }}
+
+              </details>
+
+            pr-number: ${{ github.event.number }}
+            comment-tag: execution

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Template check expects Copier-generated projects and will post a bot comment when the project needs updating w.r.t. upstream template
+
 ## [v1.1.0] - 2025-03-26
 
 ### Fixed


### PR DESCRIPTION
Now that cookiecutter is pinned to the v1.1.0 stable release of the repo, we can safely update the template checker.

This doesn't create a failing CI check (as it did with the cookiecutter template check) but comments on the PR with the need for a change. It's less aggressive, but still informs users during PRs that they may want to consider updating against upstream changes.

Also, it will only check for versioned changes (again, a change from the former functionality). So, changes on `main` in https://github.com/arup-group/pypackage-template won't be considered as relevant to trigger this bot unless there is an associated tag.

If the template is updated in a PR that initially flagged the need with a comment, the associated comment will be deleted automatically.

https://github.com/arup-group/esop-py/ has been used to test this. @jjjgoulding you'll need to point to `main` on the relevant reusable action in esop-py once this is merged. You'll also want to add this to the pypackage template in the same way as it is used in esop-py at the moment (its own CI file that is triggered on merges to `main`/`develop`).