### PR TITLE
Replace Ubuntu 20.04 runner with Ubuntu latest

### DIFF
--- a/.github/workflows/docs-a11y.yml
+++ b/.github/workflows/docs-a11y.yml
@@ -32,7 +32,7 @@ defaults:
 
 jobs:
   docs-accessibility:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: arup-group/actions-city-modelling-lab/.github/actions/create-conda-env@v1.1.0
       with:


### PR DESCRIPTION
- Closes #76 

## Before

```shell
 grep -iRn "ubuntu-20" ./.github | grep -v bak
 
./.github/workflows/docs-a11y.yml:35:    runs-on: ubuntu-20.04
```

## After
```shell
grep -iRn "ubuntu-20" ./.github | grep -v bak
```