### PR TITLE
Make the AWS upload workflow recognise all default branch names.

### DIFF
--- a/.github/workflows/aws-upload.yml
+++ b/.github/workflows/aws-upload.yml
@@ -40,7 +40,7 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: eu-west-1
     - name: Create release name
-      if: github.ref != 'refs/heads/main'
+      if: github.ref_name != github.event.repository.default_branch
       run: |
         release_name=`echo ${{ github.actor }}-${{ github.ref_name }}`
         echo "Release name: $release_name"


### PR DESCRIPTION
- Fixes #61 

We're now using the GitHub variable for the default branch name, as described [here](https://stackoverflow.com/a/69995861/16935877).

@syhwawa this will lead to Columbus builds from the `master` branch being tagged correctly in the downstream AWS CodeBuild job that publishes the Docker images to ECR, as recently discussed.

@D-Dulius @naltinel I've added you both as a learning opportunity on a one-line PR.

Validating the change is a **lot** more effort than the change itself - see below.

## Basic Validation of the Workflow File

### As a YAML file
Using [the YQ YAML processor](https://github.com/mikefarah/yq):

```shell
cat workflows/aws-upload.yml | yq

name: Reusable AWS upload workflow
on:
  workflow_call:
    secrets:
      AWS_ACCESS_KEY_ID:
        required: true
      AWS_SECRET_ACCESS_KEY:
        required: true
      AWS_S3_CODE_BUCKET:
        required: true
    inputs:
      image-tag:
        description: >
          An optional value to write into an image_tags file before zipping and uploading the repo contents. The image_tags file is used in some downstream Docker image builds to tag the image with arbitrary values.

        required: false
        type: string
        default: 'no-tags'
      zip-file-name-root:
        description: >
          An optional value to use as the name of the zip file uploaded to AWS S3. For example, the value myLovelyRepo results in myLovelyRepo.zip being uploaded to S3. Where no value is passed, the zip file will be <exact-repo-name>.zip

        required: false
        type: string
        default: 'repo-name'
jobs:
  upload-to-aws:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - name: Configure AWS credentials
        uses: aws-actions/configure-aws-credentials@v4
        with:
          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
          aws-region: eu-west-1
      - name: Create release name
        if: github.ref_name != github.event.repository.default_branch
        run: |
          release_name=`echo ${{ github.actor }}-${{ github.ref_name }}`
          echo "Release name: $release_name"
          echo $release_name > release_name
      - name: Add optional image tags
        if: inputs.image-tag != 'no-tags'
        run: |
          echo "Making an image_tags file with tag value: ${{ inputs.image-tag }}"
          echo ${{ inputs.image-tag }} > image_tags
      - name: Zip release
        run: |
          echo ${{ github.sha }} > release
          zip -r app.zip .
      - name: Push zip to S3
        run: |
          zip_file_name=${{ inputs.zip-file-name-root }}
          if [ "$zip_file_name" = "repo-name" ]; then
            echo "Using the default name for the zip file"
            zip_file_name="${{ github.event.repository.name }}"
          fi
          aws s3 cp app.zip "s3://${{ secrets.AWS_S3_CODE_BUCKET }}/$zip_file_name.zip"

```

### As an Actions Workflow 
Using [the Act CLI tool](https://github.com/nektos/act):

```shell
act --container-architecture linux/amd64 --list --workflows workflows/aws-upload.yml

INFO[0000] Using docker host 'unix:///var/run/docker.sock', and daemon socket 'unix:///var/run/docker.sock'
Stage  Job ID         Job name       Workflow name                 Workflow file   Events
0      upload-to-aws  upload-to-aws  Reusable AWS upload workflow  aws-upload.yml  workflow_call

```

#### Explanation
The Act `--list` subcommand lists all the workflows in a given directory or file. It errors if the workflow is not valid according to the [Actions Workflow Schema](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions) and thus provides validation beyond a simple check for valid YAML syntax.

For example, if I edit the AWS Upload workflow to add a valid YAML property that does not exist in the Workflow schema:

```shell
 jobs:
   upload-to-aws:
+    cheese: cheddar
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
```

```shell
act --container-architecture linux/amd64 --list --workflows workflows/aws-upload.yml

INFO[0000] Using docker host 'unix:///var/run/docker.sock', and daemon socket 'unix:///var/run/docker.sock'
Error: workflow is not valid. 'aws-upload.yml': Line: 33 Column 5: Failed to match job-factory: Line: 33 Column 5: Unknown Property cheese
Line: 33 Column 5: Failed to match workflow-job: Line: 33 Column 5: Unknown Property cheese
Line: 34 Column 5: Unknown Property runs-on
Line: 35 Column 5: Unknown Property steps
Actions YAML Schema Validation Error detected:
For more information, see: https://nektosact.com/usage/schema.html
```

## Using the Workflow File as a Reusable Action
The behaviour we want:

- If the branch is *not* the default, create a file called `release_name` in the zip file; the contents of the file are a single line with a name derived from the branch name and the name of the committer
- If the branch *is* the default (`main`/`master`/`whatevs`), don't create a `release_name` file

It's easy to test the non-default branch case (I'll make a branch of Columbus for that @syhwawa), but I think testing on actual default branches should probably wait until after we've merged this and then merged a couple of PRs that use the new version of this action. I'll leave blank sections below that I will fill in after all the merging is done, just to show that the change worked.

### With a non-default branch
#### Expected behaviour
The uploaded zip file should contain the `release_name` file.

#### Actual behaviour
From the CI workflow of a Columbus branch where I pinned to this version of `aws-upload`:

<img width="626" alt="Screenshot 2025-05-02 at 13 09 57" src="https://github.com/user-attachments/assets/77f9ebef-4995-496f-bd67-ac871575979e" />

I grabbed the zip file from S3, unzipped it, and confirmed that the `release_name` file was present and correct:

```shell
aws s3 ls s3://<bucketname>/ | grep -i columbus
                           PRE columbus/
2025-05-02 12:56:32    2700932 columbus.zip
```

```shell
aws s3 cp s3://<bucketname>/columbus.zip /tmp/
cd /tmp
mkdir columbus-zip-file
cd columbus-zip-file
mv ../columbus.zip .
unzip columbus.zip
```
```shell
ls -talh release_name
-rw-r--r--@ 1 mickyfitz  wheel    42B  2 May 12:56 release_name
```

```shell
cat release_name
mfitz-bump-aws-upload-version-in-ci-build
```

### With a repo using `master` as the default branch

#### Expected behaviour
The zip file should NOT contain the `release_name` file.

#### Actual behaviour
The zip file does not contain the `release_name` file.

<img width="1129" alt="Screenshot 2025-05-07 at 19 40 43" src="https://github.com/user-attachments/assets/8cbdf8fe-b023-45a7-979b-9e56c2329190" />

```shell
aws s3 ls s3://<bucket>/columbus.zip
2025-05-07 19:24:02    2701734 columbus.zip

aws s3 cp s3://<bucket>/columbus.zip .

unzip columbus.zip

ls -talh release_name
ls: release_name: No such file or directory
```


### With a repo using `main` as the default branch

#### Expected behaviour
The zip file should NOT contain the `release_name` file.

#### Actual behaviour
As expected, the zip file does not contain a `release_name` file:

<img width="551" alt="Screenshot 2025-05-12 at 16 05 58" src="https://github.com/user-attachments/assets/aa97f8bf-758f-4adc-bd1c-d1f87e59dffa" />


