### PR TITLE
Fix failing internal release

### DIFF
--- a/.github/workflows/conda-upload.yml
+++ b/.github/workflows/conda-upload.yml
@@ -23,6 +23,11 @@ on:
         description: "Upload packaging index destination. Must be one of [anaconda, internal]."
         type: string
         default: anaconda
+      python_version:
+        description: "Python version to be used in the conda environment"
+        required: false
+        type: string
+        default: 3.11
     secrets:
       ANACONDA_TOKEN:
         required: true
@@ -45,7 +50,7 @@ jobs:
         micromamba-version: '1.5.10-0'
         environment-name: condaupload
         create-args: >-
-            python=3.11
+            python=${{ inputs.python_version }}
             anaconda-client
         post-cleanup: all
         cache-environment: True
@@ -87,7 +92,9 @@ jobs:
         with:
           micromamba-version: '1.5.10-0'
           environment-name: condaindex
-          create-args: conda-index
+          create-args: >-
+            python=${{ inputs.python_version }}
+            conda-index
           post-cleanup: all
           cache-environment: true
           micromamba-binary-path: ${{ runner.temp }}/bin/micromamba

--- a/.github/workflows/conda-upload.yml
+++ b/.github/workflows/conda-upload.yml
@@ -53,7 +53,7 @@ jobs:
             python=${{ inputs.python_version }}
             anaconda-client
         post-cleanup: all
-        cache-environment: True
+        cache-environment: true
 
     - name: Download built conda package from another workflow
       if: inputs.build_workflow != ''
@@ -96,8 +96,8 @@ jobs:
             python=${{ inputs.python_version }}
             conda-index
           post-cleanup: all
-          cache-environment: false
-          micromamba-binary-path: ${{ runner.temp }}/bin/micromamba
+          cache-environment: true
+          #micromamba-binary-path: ${{ runner.temp }}/bin/micromamba
 
       - name: Download built conda package from another workflow
         uses: dawidd6/action-download-artifact@v9

--- a/.github/workflows/conda-upload.yml
+++ b/.github/workflows/conda-upload.yml
@@ -100,9 +100,6 @@ jobs:
           cache-environment: true
           micromamba-binary-path: ${{ runner.temp }}/bin/micromamba
 
-      - name: Do nothing step 1
-        run: echo "This step does nothing."
-
       - name: Download built conda package from another workflow
         uses: dawidd6/action-download-artifact@v9
         with:

--- a/.github/workflows/conda-upload.yml
+++ b/.github/workflows/conda-upload.yml
@@ -96,7 +96,7 @@ jobs:
             python=${{ inputs.python_version }}
             conda-index
           post-cleanup: all
-          cache-environment: true
+          cache-environment: false
           micromamba-binary-path: ${{ runner.temp }}/bin/micromamba
 
       - name: Download built conda package from another workflow

--- a/.github/workflows/conda-upload.yml
+++ b/.github/workflows/conda-upload.yml
@@ -99,6 +99,9 @@ jobs:
           cache-environment: true
           #micromamba-binary-path: ${{ runner.temp }}/bin/micromamba
 
+      - name: Do nothing step 1
+        run: echo "This step does nothing."
+
       - name: Download built conda package from another workflow
         uses: dawidd6/action-download-artifact@v9
         with:

--- a/.github/workflows/conda-upload.yml
+++ b/.github/workflows/conda-upload.yml
@@ -83,7 +83,8 @@ jobs:
 
   conda-internal-publish:
     if: inputs.destination == 'internal'
-    runs-on: [self-hosted, linux, packages]
+    #runs-on: [self-hosted, linux, packages]
+    runs-on: ubuntu-latest
     env:
       ARTIFACTNAME: "conda-build[a-zA-Z0-9-.]*-${{ inputs.package_name }}-${{ inputs.version }}"
       PACKAGENAME: "conda-build-*-${{ inputs.package_name }}-${{ inputs.version }}"
@@ -97,7 +98,7 @@ jobs:
             conda-index
           post-cleanup: all
           cache-environment: true
-          #micromamba-binary-path: ${{ runner.temp }}/bin/micromamba
+          micromamba-binary-path: ${{ runner.temp }}/bin/micromamba
 
       - name: Do nothing step 1
         run: echo "This step does nothing."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Template check expects Copier-generated projects and will post a bot comment when the project needs updating w.r.t. upstream template
+- conda-upload workflow now takes input for python version and passess to mamba environment creation
 
 ## [v1.1.0] - 2025-03-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Template check expects Copier-generated projects and will post a bot comment when the project needs updating w.r.t. upstream template
-- conda-upload workflow now takes input for python version and passess to mamba environment creation
+- conda-upload workflow now takes input for python version and passess to mamba environment creation (#83)
 
 ## [v1.1.0] - 2025-03-26
 


### PR DESCRIPTION
Update conda-upload workflow to allow user to specify python version.

Fixes error of mamba using incompatible version by allowing user control of python version using by setup-micromamba@v2