### PR TITLE
Fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate-reusable-workflows.yml
+++ b/.github/workflows/validate-reusable-workflows.yml
@@ -20,12 +20,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           submodules: true
 
       - name: Install action-validator with asdf
-        uses: asdf-vm/actions/install@v3
+        uses: asdf-vm/actions/install@b7bcd026f18772e44fe1026d729e1611cc435d47  # v4.0.1
         with:
           tool_versions: action-validator 0.5.3
 

--- a/.github/workflows/validate-reusable-workflows.yml
+++ b/.github/workflows/validate-reusable-workflows.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: bash


### PR DESCRIPTION
- Closes #120 

- Fixes [https://github.com/arup-group/actions-city-modelling-lab/security/code-scanning/1](https://github.com/arup-group/actions-city-modelling-lab/security/code-scanning/1)

Adds an explicit `permissions` block in `.github/workflows/validate-reusable-workflows.yml` at the workflow root (top-level), so it applies to all jobs unless overridden.  
For this workflow, the minimal required permission is `contents: read` (needed by `actions/checkout` to read repository contents).

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
