### PR TITLE
Use a less prescriptive tar file name in the pip-build workflow

### DIFF
--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -97,7 +97,16 @@ jobs:
 
     - name: try installing from local build
       run: |
-        pip install ${{inputs.pip_args}} dist/${{ inputs.package_name }}-*.tar.gz
+        shopt -s nullglob
+        sdists=(dist/*.tar.gz)
+
+        if [ "${#sdists[@]}" -ne 1 ]; then
+          echo "Expected exactly one source distribution in dist/, found ${#sdists[@]}"
+          ls -la dist/
+          exit 1
+        fi
+
+        pip install ${{ inputs.pip_args }} "${sdists[0]}"
 
   pip-test-upload:  # upload to test-pypi and then check install from there succeeds
     needs: [pip-build, pip-test-build]


### PR DESCRIPTION
- Fixes #122 

@LuisMartinParraMorales and @anarcoteron - I have added you both only for your own reference; feel free to review if you like, but don't feel obliged. @Hussein-Mahfouz - you have all the context needed to review this.

## The Fix

Rather than assume a tar file name using hyphens, the `pip install` step now discovers the file name before trying to install

## Validation

### Basic local validation of the workflow file

I used the [`act`](https://github.com/nektos/act) tool to validate that the workflow file is both a valid YAML and a valid actions file.

```
which actions-validate
```
```
actions-validate () {
	act --container-architecture linux/amd64 --list --workflows $1
}
```

```shell
actions-validate .github/workflows/pip-build.yml

INFO[0000] Using docker host 'unix:///var/run/docker.sock', and daemon socket 'unix:///var/run/docker.sock'
Stage  Job ID           Job name         Workflow name                   Workflow file  Events
0      pip-build        pip-build        Reusable conda package builder  pip-build.yml  workflow_call
1      pip-test-build   pip-test-build   Reusable conda package builder  pip-build.yml  workflow_call
2      pip-test-upload  pip-test-upload  Reusable conda package builder  pip-build.yml  workflow_call
```

### Using the amended workflow in another repo

We pointed the `pre-release.yml` workflow in PAM at this branch version of the `pip-build` workflow, and the previously failing build now succeeds.